### PR TITLE
URL Validator

### DIFF
--- a/datamanager/nodejs/items/validator/url.test.ts
+++ b/datamanager/nodejs/items/validator/url.test.ts
@@ -1,0 +1,23 @@
+import ItemValidatorUrl from './url';
+
+describe('items/validator/url', () => {
+  const urlValidator = new ItemValidatorUrl();
+
+  test('半角文字かどうか', () => {
+    expect(() => urlValidator.validateDataType(1000)).toThrow(
+      'URLは文字列である必要があります。'
+    );
+    expect(() => urlValidator.validateDataType(true)).toThrow(
+      'URLは文字列である必要があります。'
+    );
+  });
+
+  test('有効なURLかどうか', () => {
+    expect(() => urlValidator.validateDataType('https//google.com')).toThrow(
+      '入力がURLとして認識されません。'
+    );
+    expect(() => urlValidator.validateDataType('google．com')).toThrow(
+      '入力がURLとして認識されません。'
+    );
+  });
+});

--- a/datamanager/nodejs/items/validator/url.ts
+++ b/datamanager/nodejs/items/validator/url.ts
@@ -1,0 +1,17 @@
+class ItemValidatorUrl {
+  validateDataType(data: any) {
+    if (typeof data != 'string') {
+      throw new Error('URLは文字列である必要があります。');
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const unused = new URL(data);
+    } catch {
+      throw new Error('入力がURLとして認識されません。');
+    }
+    return;
+  }
+}
+
+export default ItemValidatorUrl;


### PR DESCRIPTION
close #14 

[JSのURLオブジェクト](https://developer.mozilla.org/ja/docs/Web/API/URL/URL)に値を入れ、無効であればTypeErrorを吐くのでそれをキャッチして日本語のエラーメッセージを吐く。定義書の型は[xsd:anyURI](http://www.datypic.com/sc/xsd/t-xsd_anyURI.html)で、https:// が入っていなくても型としては問題ないっぽいので特別に正規表現を書くなどはしませんでした。