### PR TITLE
[webclient]normalize-label画面のスタイルを調整

### DIFF
--- a/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
+++ b/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
@@ -1,4 +1,4 @@
-import { Grid, GridItem } from '@chakra-ui/react';
+import { Box, Flex, Text } from '@chakra-ui/react';
 import { FC, useEffect, useMemo } from 'react';
 import { useRecoilState } from 'recoil';
 import { datasetItemAtom } from '../../stores/dataset';
@@ -29,10 +29,7 @@ export const NormalizeDatasetItemLabel: FC<Params> = ({ datasetUid, itemUid }) =
     return;
   };
 
-  const handleOriginalCheck = () => {
-    // 独自定義かどうかの選択処理
-    // 独自定義の場合はrowLabelをそのままnormalizedLabelにいれる
-  };
+  const isLabelOriginal = false; //TODO: 独自定義かどうかチェックする
 
   const handleSelect = (v: string) => {
     if (!item) return;
@@ -49,30 +46,42 @@ export const NormalizeDatasetItemLabel: FC<Params> = ({ datasetUid, itemUid }) =
   }, []);
 
   return (
-    <Grid gridTemplateColumns="70px 120px 1fr 1fr" mb={2}>
-      <GridItem>
+    <Flex
+      alignItems="center"
+      justifyContent="space-between"
+      py={4}
+      borderTop="1px solid"
+      borderColor="icon.disabled"
+    >
+      <Box flex="1 1 40%">
         <OstCheckbox
           defaultChecked={item?.isActive}
           onChange={() => {
             handleIsActiveCheck();
           }}
-        />
-      </GridItem>
-      <GridItem>
-        <OstCheckbox
-          onChange={() => {
-            handleOriginalCheck();
-          }}
-        />
-      </GridItem>
-      <GridItem>{item?.rowLabel}</GridItem>
-      <GridItem>
+        >
+          {item?.rowLabel}
+        </OstCheckbox>
+      </Box>
+      <Flex flex="1 1 60%">
+        <Box p={4}>
+          <Text
+            px={4}
+            py={2}
+            bg={isLabelOriginal ? 'information.bg.alert' : 'information.bg.disabled'}
+            borderRadius="3em"
+            whiteSpace="nowrap"
+            cursor="default"
+          >
+            {isLabelOriginal ? '項目名を選択' : '一致しました'}
+          </Text>
+        </Box>
         <OstSelect
           value={item?.normalizedLabel || ''}
           onChange={(e) => handleSelect(e.target.value)}
           options={selectOptions}
         />
-      </GridItem>
-    </Grid>
+      </Flex>
+    </Flex>
   );
 };

--- a/webclient/src/components/Elements/OstSelect/OstSelect.tsx
+++ b/webclient/src/components/Elements/OstSelect/OstSelect.tsx
@@ -27,9 +27,11 @@ export type OstSelectProps = {
 };
 
 export const OstSelect = forwardRef<SelectProps & OstSelectProps, 'select'>((props, ref) => {
-  const isError = props.isRequired ? props.value === '' : false;
+  const { changeValue, ...selectProps } = props;
 
-  const optionItems = props.options.map((item, index) => (
+  const isError = selectProps.isRequired ? selectProps.value === '' : false;
+
+  const optionItems = selectProps.options.map((item, index) => (
     <option key={`option-${index}`} value={item.value}>
       {item.label}
     </option>
@@ -37,24 +39,24 @@ export const OstSelect = forwardRef<SelectProps & OstSelectProps, 'select'>((pro
 
   return (
     <FormControl
-      isRequired={props.isRequired || false}
-      isDisabled={props.isDisabled}
+      isRequired={selectProps.isRequired || false}
+      isDisabled={selectProps.isDisabled}
       isInvalid={isError}
     >
-      {props.label && <OstFormLabel>{props.label}</OstFormLabel>}
+      {selectProps.label && <OstFormLabel>{selectProps.label}</OstFormLabel>}
       <Select
         ref={ref}
-        value={props.value}
-        onChange={(e) => props.changeValue?.(e)}
-        placeholder={props.placeholder}
-        {...props}
+        value={selectProps.value}
+        onChange={(e) => changeValue?.(e)}
+        placeholder={selectProps.placeholder}
+        {...selectProps}
       >
         {optionItems}
       </Select>
-      {!isError && props.helperText ? (
-        <FormHelperText>{props.helperText}</FormHelperText>
+      {!isError && selectProps.helperText ? (
+        <FormHelperText>{selectProps.helperText}</FormHelperText>
       ) : (
-        <FormErrorMessage>{props.errorMessage}</FormErrorMessage>
+        <FormErrorMessage>{selectProps.errorMessage}</FormErrorMessage>
       )}
     </FormControl>
   );

--- a/webclient/src/features/normalize-label/routes/NormalizeLabel.tsx
+++ b/webclient/src/features/normalize-label/routes/NormalizeLabel.tsx
@@ -1,12 +1,13 @@
-import { Avatar, Box, Divider, Flex, Grid, GridItem } from '@chakra-ui/react';
-import { FC } from 'react';
+import { FC, useState } from 'react';
+import { Avatar, Box, Flex, Text, Spinner } from '@chakra-ui/react';
+import { ArrowBackIcon, ArrowForwardIcon, DownloadIcon, InfoOutlineIcon } from '@chakra-ui/icons';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { NormalizeDatasetItemLabel } from '../../../components/Editor';
 import { StepLayout } from '../../../components/Layout';
 import { OstNavLink } from '../../../components/Elements/OstLink';
 import { OstSelect } from '../../../components/Elements/OstSelect';
-import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
+import { OstButton } from '../../../components/Elements/OstButton';
 import { datasetItemUidListAtom } from '../../../stores/dataset';
 
 export const NormalizeLabel: FC = () => {
@@ -14,42 +15,111 @@ export const NormalizeLabel: FC = () => {
   const datasetItemUidList = useRecoilValue(
     datasetItemUidListAtom({ datasetUid: String(dataset_uid) })
   );
+  const [isFormatSelected, setIsFormatSelected] = useState<boolean>(false); //TODO: 確認終了のステータスを監視する
+  const isCheckFinished = true; //TODO: 確認終了のステータスを監視する
 
   return (
-    <StepLayout pageTitle="項目名の正規化" headingText="データ項目名の正規化" uid={dataset_uid}>
-      <Box my={4}>
-        <OstSelect
-          label="データセット名を選択してください。"
-          options={[{ label: '公共施設一覧', value: 'public-facility' }]}
-        />
-      </Box>
-      <Divider my={10} borderColor="black" />
-      <Grid gridTemplateColumns="70px 120px 1fr 1fr" mb={5}>
-        <GridItem>対象</GridItem>
-        <GridItem>独自定義</GridItem>
-        <GridItem>インポートしたデータ項目名</GridItem>
-        <GridItem>正規化されたデータ項目名</GridItem>
-      </Grid>
-
-      {datasetItemUidList.map((uid) => (
-        <NormalizeDatasetItemLabel datasetUid={String(dataset_uid)} itemUid={uid} key={uid} />
-      ))}
-
-      <Flex mt={4} justifyContent="space-between">
-        <OstNavLink
-          to={`/${dataset_uid}/auto-convert`}
-          iconLeft={<Avatar size="md" p="12px" icon={<ArrowBackIcon />} />}
-        >
-          ステップ２に戻る
-        </OstNavLink>
-        <OstNavLink
-          to={`/${dataset_uid}/data-editor`}
-          isDisabled={false}
-          iconRight={<Avatar size="md" p="12px" icon={<ArrowForwardIcon />} />}
-        >
-          次のステップへ
-        </OstNavLink>
+    <StepLayout
+      pageTitle="データ項目名の正規化"
+      headingText="データ項目名の正規化"
+      uid={dataset_uid}
+    >
+      <Flex
+        alignItems="center"
+        p={8}
+        mb={4}
+        borderRadius={20}
+        bg={isFormatSelected ? 'information.bg.disabled' : 'information.bg.active'}
+      >
+        <Box flex="0 0 50%" pr={8}>
+          <Text>正規化したい推奨データフォーマットを選択してください</Text>
+        </Box>
+        <Box flex="0 0 50%">
+          <OstSelect
+            options={[
+              { label: 'フォーマットを選択', value: '' },
+              { label: '公共施設一覧', value: 'public-facility' },
+            ]}
+            changeValue={() => setIsFormatSelected(true)}
+          />
+        </Box>
       </Flex>
+
+      {isFormatSelected && (
+        <>
+          <Flex
+            alignItems="center"
+            px={6}
+            py={4}
+            mb={10}
+            bg={isCheckFinished ? 'information.bg.alert' : 'information.bg.active'}
+            borderRadius={8}
+          >
+            {isCheckFinished ? (
+              <>
+                <InfoOutlineIcon />
+                <Text ml={6}>
+                  推奨データフォーマットの項目名と一致した項目はチェック済みです。
+                  <br />
+                  未チェックの項目で正規化できる項目があれば、チェックを入れ正規化する対象項目を選択してください。
+                </Text>
+              </>
+            ) : (
+              <>
+                <Spinner />
+                <Text ml={6}>推奨データフォーマットと照合しています</Text>
+              </>
+            )}
+          </Flex>
+          {isCheckFinished &&
+            datasetItemUidList.map((uid) => (
+              <NormalizeDatasetItemLabel datasetUid={String(dataset_uid)} itemUid={uid} key={uid} />
+            ))}
+        </>
+      )}
+
+      <Box mt={8}>
+        {isFormatSelected && isCheckFinished && (
+          <Flex justifyContent="flex-end">
+            <Text
+              display="inline-block"
+              bg="information.bg.active"
+              borderRadius="3em"
+              px={8}
+              py={2}
+            >
+              次のステップでは各項目ごとのデータ修正を行います
+            </Text>
+          </Flex>
+        )}
+        <Flex mt={8} justifyContent="space-between">
+          <Flex flexWrap="wrap">
+            <OstNavLink
+              to={`/${dataset_uid}/auto-convert`}
+              iconLeft={<Avatar size="md" p="12px" icon={<ArrowBackIcon />} />}
+              mr={8}
+            >
+              ステップ２に戻る
+            </OstNavLink>
+            {isCheckFinished && (
+              <OstButton
+                view="skeleton"
+                size="L"
+                icon={<Avatar bg="bg.active" size="md" p="12px" icon={<DownloadIcon />} />}
+              >
+                一時ファイルのダウンロード
+              </OstButton>
+            )}
+          </Flex>
+          <OstNavLink
+            to={`/${dataset_uid}/data-editor`}
+            isDisabled={!isFormatSelected || !isCheckFinished}
+            iconRight={<Avatar size="md" p="12px" icon={<ArrowForwardIcon />} />}
+          >
+            次のステップへ
+          </OstNavLink>
+        </Flex>
+      </Box>
     </StepLayout>
   );
 };

--- a/webclient/src/features/normalize-label/routes/NormalizeLabel.tsx
+++ b/webclient/src/features/normalize-label/routes/NormalizeLabel.tsx
@@ -101,7 +101,7 @@ export const NormalizeLabel: FC = () => {
             >
               ステップ２に戻る
             </OstNavLink>
-            {isCheckFinished && (
+            {isFormatSelected && isCheckFinished && (
               <OstButton
                 view="skeleton"
                 size="L"

--- a/webclient/src/theme/components/select.ts
+++ b/webclient/src/theme/components/select.ts
@@ -39,12 +39,20 @@ const iconSpacing = defineStyle({
   paddingInlineEnd: '8',
 });
 
+const customField = defineStyle({
+  padding: '24px',
+  paddingRight: '36px',
+  height: 'auto',
+  background: 'white',
+});
+
 const sizes = {
   lg: {
     ...inputTheme.sizes?.lg,
     field: {
       ...inputTheme.sizes?.lg.field,
       ...iconSpacing,
+      ...customField,
     },
   },
   md: {
@@ -52,6 +60,7 @@ const sizes = {
     field: {
       ...inputTheme.sizes?.md.field,
       ...iconSpacing,
+      ...customField,
     },
   },
   sm: {
@@ -59,6 +68,7 @@ const sizes = {
     field: {
       ...inputTheme.sizes?.sm.field,
       ...iconSpacing,
+      ...customField,
     },
   },
   xs: {
@@ -66,6 +76,7 @@ const sizes = {
     field: {
       ...inputTheme.sizes?.xs.field,
       ...iconSpacing,
+      ...customField,
     },
     icon: {
       insetEnd: '1',

--- a/webclient/src/theme/foundations/colors.ts
+++ b/webclient/src/theme/foundations/colors.ts
@@ -28,6 +28,13 @@ const colors = {
   inputAreaBorder: {
     active: '#CCC',
   },
+  information: {
+    bg: {
+      alert: '#FFDE6A',
+      active: 'rgba(115, 205, 255, 0.4)',
+      disabled: 'rgba(204, 204, 204, 0.4)',
+    },
+  },
 };
 
 export default colors;


### PR DESCRIPTION
close #81 

- 便宜上 `webclient/src/theme/foundations/colors.ts` のファイルを #93 とダブらせてコミットしています。
- OstSelectコンポーネントのpropsのワーニングを修正しています。

![データ項目名の正規化-Bulletproof-React](https://user-images.githubusercontent.com/14883063/194706517-737678e0-005d-44af-a65f-36521b2f890b.png)

![データ項目名の正規化-Bulletproof-React (1)](https://user-images.githubusercontent.com/14883063/194706526-7bb68fec-1f31-4d53-9775-cdb464af8306.png)

![データ項目名の正規化-Bulletproof-React (2)](https://user-images.githubusercontent.com/14883063/194706537-8e161112-d8ed-4c4a-b1ed-64679d0c6834.png)


