### PR TITLE
[webclient]auto-convert画面のスタイルを調整

### DIFF
--- a/webclient/src/features/auto-convert/routes/AutoConvert.tsx
+++ b/webclient/src/features/auto-convert/routes/AutoConvert.tsx
@@ -1,8 +1,16 @@
-import { ArrowBackIcon, ArrowForwardIcon, CheckCircleIcon, MinusIcon } from '@chakra-ui/icons';
-import { Avatar, Box, Flex, Spinner } from '@chakra-ui/react';
+import { Avatar, Box, Flex, Spinner, Text } from '@chakra-ui/react';
+import {
+  ArrowBackIcon,
+  ArrowForwardIcon,
+  CheckIcon,
+  MinusIcon,
+  DownloadIcon,
+  InfoOutlineIcon,
+} from '@chakra-ui/icons';
 import { FC, useEffect, useState } from 'react';
 import { StepLayout } from '../../../components/Layout';
 import { OstNavLink } from '../../../components/Elements/OstLink';
+import { OstButton } from '../../../components/Elements/OstButton';
 import { useParams } from 'react-router-dom';
 
 export const AutoConvert: FC = () => {
@@ -40,75 +48,229 @@ export const AutoConvert: FC = () => {
     fetch();
   }, []);
 
+  const statusStyle = (status: string) => {
+    switch (status) {
+      case 'waiting':
+        return {
+          bg: 'white',
+          color: 'text.disabled',
+          border: '1px solid',
+          borderColor: 'inputAreaBorder.active',
+        };
+      case 'processing':
+        return {
+          bg: 'information.bg.active',
+          color: 'body.text',
+        };
+      case 'finished':
+        return {
+          bg: 'information.bg.disabled',
+          color: 'icon.active',
+        };
+      default:
+        return {
+          bg: 'white',
+          color: 'text.disabled',
+          border: '1px solid',
+          borderColor: 'inputAreaBorder.active',
+        };
+    }
+  };
+
   const CharacterCodeStatusElm: FC = () => {
     switch (progress.characterCode.status) {
       case 'waiting':
-        return <MinusIcon />;
+        return (
+          <>
+            <MinusIcon mr={6} />
+            <Text>文字コードを確認しています</Text>
+          </>
+        );
       case 'processing':
-        return <Spinner />;
+        return (
+          <>
+            <Spinner mr={6} w={5} h={5} />
+            <Text>文字コードを変換しています</Text>
+          </>
+        );
       case 'finished':
-        return <CheckCircleIcon />;
+        return (
+          <>
+            <CheckIcon mr={6} />
+            <Text>文字コードを変換しました</Text>
+          </>
+        );
       default:
-        return <MinusIcon />;
+        return (
+          <>
+            <MinusIcon mr={6} />
+            <Text>文字コードを確認しています</Text>
+          </>
+        );
     }
   };
 
   const CharacterTypeStatusElm: FC = () => {
     switch (progress.characterType.status) {
       case 'waiting':
-        return <MinusIcon />;
+        return (
+          <>
+            <MinusIcon mr={6} />
+            <Text>全角半角を確認しています</Text>
+          </>
+        );
       case 'processing':
-        return <Spinner />;
+        return (
+          <>
+            <Spinner mr={6} w={5} h={5} />
+            <Text>全角半角変換しています</Text>
+          </>
+        );
       case 'finished':
-        return <CheckCircleIcon />;
+        return (
+          <>
+            <CheckIcon mr={6} />
+            <Text>全角半角変換しました</Text>
+          </>
+        );
       default:
-        return <MinusIcon />;
+        return (
+          <>
+            <MinusIcon mr={6} />
+            <Text>全角半角を確認しています</Text>
+          </>
+        );
     }
   };
 
   const RequiredFieldStatusElm: FC = () => {
     switch (progress.requiredField.status) {
       case 'waiting':
-        return <MinusIcon />;
+        return (
+          <>
+            <MinusIcon mr={6} />
+            <Text>必須項目を確認しています</Text>
+          </>
+        );
       case 'processing':
-        return <Spinner />;
+        return (
+          <>
+            <Spinner mr={6} w={5} h={5} />
+            <Text>必須項目を変換しています</Text>
+          </>
+        );
       case 'finished':
-        return <CheckCircleIcon />;
+        return (
+          <>
+            <CheckIcon mr={6} />
+            <Text>必須項目を確認しました</Text>
+          </>
+        );
       default:
-        return <MinusIcon />;
+        return (
+          <>
+            <MinusIcon mr={6} />
+            <Text>必須項目を確認しています</Text>
+          </>
+        );
     }
   };
 
+  const isAllProgressFinished = false; //TODO: 処理完了のステータスを監視する
+
   return (
-    <StepLayout pageTitle="自動変換" headingText={`データを自動変換しています`} uid={dataset_uid}>
-      <Box p={5} background="gray.200" border="1px solid" my={3}>
-        <CharacterCodeStatusElm />
-        文字コードを変換しています。
-      </Box>
-      <Box p={5} background="gray.200" border="1px solid" my={3}>
-        <CharacterTypeStatusElm />
-        全角英数字を半角英数字に変換しています。
-      </Box>
-      <Box p={5} background="gray.200" border="1px solid" my={3}>
-        <RequiredFieldStatusElm />
-        必須項目を確認しています。
+    <StepLayout
+      pageTitle="データ自動変換"
+      headingText={
+        isAllProgressFinished ? 'データの自動変換が完了しました' : 'データを自動変換しています'
+      }
+      uid={dataset_uid}
+    >
+      {!isAllProgressFinished && (
+        <Flex alignItems="center" px={6} py={4} bg="information.bg.alert" borderRadius={8}>
+          <InfoOutlineIcon />
+          <Text ml={6}>変換には時間がかかります。しばらくお待ちください。</Text>
+        </Flex>
+      )}
+
+      <Box py={4}>
+        <Flex
+          alignItems="center"
+          px={6}
+          py={4}
+          my={6}
+          borderRadius={8}
+          textStyle="navigationLarge"
+          {...statusStyle(progress.characterCode.status)}
+        >
+          <CharacterCodeStatusElm />
+        </Flex>
+        <Flex
+          alignItems="center"
+          px={6}
+          py={4}
+          my={6}
+          borderRadius={8}
+          textStyle="navigationLarge"
+          {...statusStyle(progress.characterType.status)}
+        >
+          <CharacterTypeStatusElm />
+        </Flex>
+        <Flex
+          alignItems="center"
+          px={6}
+          py={4}
+          my={6}
+          borderRadius={8}
+          textStyle="navigationLarge"
+          {...statusStyle(progress.requiredField.status)}
+        >
+          <RequiredFieldStatusElm />
+        </Flex>
       </Box>
 
-      <Flex mt={4} justifyContent="space-between">
-        <OstNavLink
-          to="/upload-file"
-          iconLeft={<Avatar size="md" p="12px" icon={<ArrowBackIcon />} />}
-        >
-          ステップ１に戻る
-        </OstNavLink>
-        <OstNavLink
-          to={`/${dataset_uid}/normalize-label`}
-          isDisabled={false}
-          iconRight={<Avatar size="md" p="12px" icon={<ArrowForwardIcon />} />}
-        >
-          次のステップへ
-        </OstNavLink>
-      </Flex>
+      <Box mt={8}>
+        {isAllProgressFinished && (
+          <Flex justifyContent="flex-end">
+            <Text
+              display="inline-block"
+              bg="information.bg.active"
+              borderRadius="3em"
+              px={8}
+              py={2}
+            >
+              次のステップではデータ項目名の正規化を行います
+            </Text>
+          </Flex>
+        )}
+        <Flex mt={8} justifyContent="space-between">
+          <Flex flexWrap="wrap">
+            <OstNavLink
+              to="/upload-file"
+              iconLeft={<Avatar size="md" p="12px" icon={<ArrowBackIcon />} />}
+              mr={8}
+            >
+              ステップ１に戻る
+            </OstNavLink>
+            {isAllProgressFinished && (
+              <OstButton
+                view="skeleton"
+                size="L"
+                icon={<Avatar bg="bg.active" size="md" p="12px" icon={<DownloadIcon />} />}
+              >
+                一時ファイルのダウンロード
+              </OstButton>
+            )}
+          </Flex>
+          <OstNavLink
+            to={`/${dataset_uid}/normalize-label`}
+            isDisabled={!isAllProgressFinished}
+            iconRight={<Avatar size="md" p="12px" icon={<ArrowForwardIcon />} />}
+          >
+            次のステップへ
+          </OstNavLink>
+        </Flex>
+      </Box>
     </StepLayout>
   );
 };

--- a/webclient/src/theme/foundations/colors.ts
+++ b/webclient/src/theme/foundations/colors.ts
@@ -28,6 +28,13 @@ const colors = {
   inputAreaBorder: {
     active: '#CCC',
   },
+  information: {
+    bg: {
+      alert: '#FFDE6A',
+      active: 'rgba(115, 205, 255, 0.4)',
+      disabled: 'rgba(204, 204, 204, 0.4)',
+    },
+  },
 };
 
 export default colors;


### PR DESCRIPTION
close #80 

- 便宜上 `webclient/src/theme/foundations/colors.ts` のファイルを https://github.com/codeforjapan/OpenDataTools/pull/93 とダブらせてコミットしています。

![データ自動変換-Bulletproof-React](https://user-images.githubusercontent.com/14883063/194788699-df58d843-70cc-4944-afbe-665496970858.png)

![データ自動変換-Bulletproof-React (1)](https://user-images.githubusercontent.com/14883063/194788707-8f735980-f7d4-455a-b67b-b0b7ffd26f23.png)
