### PR TITLE
[webclient]処理終了時にプログレスバーにチェックを表示する

### DIFF
--- a/webclient/src/components/Layout/StepLayout.tsx
+++ b/webclient/src/components/Layout/StepLayout.tsx
@@ -9,6 +9,7 @@ type StepLayoutProps = {
   headingText: string;
   pageTitle: string;
   uid?: string;
+  isProcessFinished?: boolean;
 };
 
 export const StepLayout = (props: StepLayoutProps) => {
@@ -92,7 +93,10 @@ export const StepLayout = (props: StepLayoutProps) => {
                       : {}
                   }
                 >
-                  {index < currentIndex && <CheckIcon color="white" />}
+                  {(index < currentIndex ||
+                    (index === currentIndex && props.isProcessFinished)) && (
+                    <CheckIcon color="white" />
+                  )}
                 </Flex>
                 <Box
                   w="100%"

--- a/webclient/src/features/auto-convert/routes/AutoConvert.tsx
+++ b/webclient/src/features/auto-convert/routes/AutoConvert.tsx
@@ -185,6 +185,7 @@ export const AutoConvert: FC = () => {
         isAllProgressFinished ? 'データの自動変換が完了しました' : 'データを自動変換しています'
       }
       uid={dataset_uid}
+      isProcessFinished={isAllProgressFinished}
     >
       {!isAllProgressFinished && (
         <Flex alignItems="center" px={6} py={4} bg="information.bg.alert" borderRadius={8}>

--- a/webclient/src/features/data-editor/routes/DataEditor.tsx
+++ b/webclient/src/features/data-editor/routes/DataEditor.tsx
@@ -20,7 +20,12 @@ export const DataEditor: FC = () => {
   const isCheckFinished = false; //TODO: 確認終了のステータスを監視する
 
   return (
-    <StepLayout pageTitle="データ形式確認" headingText="データ形式確認" uid={dataset_uid}>
+    <StepLayout
+      pageTitle="データ形式確認"
+      headingText="データ形式確認"
+      uid={dataset_uid}
+      isProcessFinished={isCheckFinished}
+    >
       <Flex
         alignItems="center"
         px={6}

--- a/webclient/src/features/normalize-label/routes/NormalizeLabel.tsx
+++ b/webclient/src/features/normalize-label/routes/NormalizeLabel.tsx
@@ -23,6 +23,7 @@ export const NormalizeLabel: FC = () => {
       pageTitle="データ項目名の正規化"
       headingText="データ項目名の正規化"
       uid={dataset_uid}
+      isProcessFinished={isFormatSelected && isCheckFinished}
     >
       <Flex
         alignItems="center"

--- a/webclient/src/features/upload/routes/FileUpload.tsx
+++ b/webclient/src/features/upload/routes/FileUpload.tsx
@@ -40,7 +40,11 @@ export const FileUpload: FC = () => {
   };
 
   return (
-    <StepLayout pageTitle="CSVアップロード" headingText={`CSVファイルをアップロードしてください`}>
+    <StepLayout
+      pageTitle="CSVアップロード"
+      headingText={`CSVファイルをアップロードしてください`}
+      isProcessFinished={!!datasetUid}
+    >
       <Box
         p={20}
         mt={4}


### PR DESCRIPTION
close #91 

チェック表示の条件としては、ページネーションの「次へ」ボタンのactiveと同じです。

![CSVアップロード-Bulletproof-React](https://user-images.githubusercontent.com/14883063/194823182-6bf47c56-7fce-4c5d-a702-2cf75300eafa.png)
