### PR TITLE
独自項目・レコメンド項目まわりの処理を修正

### DIFF
--- a/webclient/src/components/Editor/DataEditorSidenav.tsx
+++ b/webclient/src/components/Editor/DataEditorSidenav.tsx
@@ -3,7 +3,7 @@ import { InfoOutlineIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { FC } from 'react';
 import { useParams } from 'react-router';
 import { useRecoilValue } from 'recoil';
-import { datasetItemAtom, datasetItemUidListAtom } from '../../stores/dataset';
+import { datasetItemAtom, datasetItemListSelector } from '../../stores/dataset';
 
 type Props = {
   selectedItemUid?: string;
@@ -12,8 +12,8 @@ type Props = {
 
 export const DataEditorSidenav: FC<Props> = ({ onSelect, selectedItemUid }) => {
   const { dataset_uid } = useParams<{ dataset_uid: string }>();
-  const datasetItemUidList = useRecoilValue(
-    datasetItemUidListAtom({ datasetUid: String(dataset_uid) })
+  const datasetItemList = useRecoilValue(
+    datasetItemListSelector({ datasetUid: String(dataset_uid) })
   );
 
   const DatasetItem: FC<{ datasetUid: string; itemUid: string }> = ({ datasetUid, itemUid }) => {
@@ -46,7 +46,7 @@ export const DataEditorSidenav: FC<Props> = ({ onSelect, selectedItemUid }) => {
         <Flex alignItems="center" overflow="hidden">
           <InfoOutlineIcon color="icon.active" />
           <Text px={2} overflow="hidden" whiteSpace="nowrap" textOverflow="ellipsis">
-            {item?.normalizedLabel}
+            {item?.normalizedLabel || item?.rowLabel}
           </Text>
         </Flex>
         {item?.uid === selectedItemUid && <ChevronRightIcon />}
@@ -56,9 +56,11 @@ export const DataEditorSidenav: FC<Props> = ({ onSelect, selectedItemUid }) => {
 
   return (
     <Box ml="-40px">
-      {datasetItemUidList.map((itemUid, index) => (
-        <DatasetItem key={index} itemUid={itemUid} datasetUid={String(dataset_uid)} />
-      ))}
+      {datasetItemList
+        .filter((item) => item.isActive)
+        .map((item, index) => (
+          <DatasetItem key={index} itemUid={item.uid} datasetUid={String(dataset_uid)} />
+        ))}
     </Box>
   );
 };

--- a/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
+++ b/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
@@ -70,7 +70,7 @@ export const NormalizeDatasetItemLabel: FC<Params> = ({ datasetUid, itemUid }) =
         </OstCheckbox>
       </Box>
       <Flex flex="1 1 70%">
-        <Flex p={4} flex="0 0 20em" justifyContent="flex-end">
+        <Flex p={4} flex="0 0 21em" justifyContent="flex-end">
           {isLabelOriginal && (
             <Flex
               alignItems="center"

--- a/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
+++ b/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
@@ -25,7 +25,7 @@ export const NormalizeDatasetItemLabel: FC<Params> = ({ datasetUid, itemUid }) =
       setIsLabelRecommend(true);
       setIsLabelOriginal(true);
     } else if (success) {
-      setItem({ ...item, normalizedLabel: item.rowLabel });
+      setItem({ ...item, normalizedLabel: item.rowLabel, isActive: true });
     } else {
       setIsLabelOriginal(true);
     }

--- a/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
+++ b/webclient/src/components/Editor/NormalizeDatasetItemLabel.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
-import { FC, useEffect, useMemo } from 'react';
+import { InfoOutlineIcon } from '@chakra-ui/icons';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { datasetItemAtom } from '../../stores/dataset';
 import { itemLabelFormatter, itemsListOfPublicFacilities } from 'opendatatool-datamanager';
@@ -13,23 +14,28 @@ type Params = {
 
 export const NormalizeDatasetItemLabel: FC<Params> = ({ datasetUid, itemUid }) => {
   const [item, setItem] = useRecoilState(datasetItemAtom({ datasetUid, itemUid }));
+  const [isLabelOriginal, setIsLabelOriginal] = useState<boolean>(false);
+  const [isLabelRecommend, setIsLabelRecommend] = useState<boolean>(false);
 
   useEffect(() => {
     if (!item?.rowLabel) return;
     const { recommend, success, collectedLabel } = itemLabelFormatter.format(item.rowLabel);
     if (recommend && success) {
       setItem({ ...item, normalizedLabel: collectedLabel });
+      setIsLabelRecommend(true);
+      setIsLabelOriginal(true);
     } else if (success) {
       setItem({ ...item, normalizedLabel: item.rowLabel });
+    } else {
+      setIsLabelOriginal(true);
     }
   }, [item?.rowLabel]);
 
-  const handleIsActiveCheck = () => {
-    // 該当項目を使うかどうかの選択処理
+  const handleIsActiveCheck = (c: boolean) => {
+    if (!item) return;
+    setItem({ ...item, isActive: c });
     return;
   };
-
-  const isLabelOriginal = false; //TODO: 独自定義かどうかチェックする
 
   const handleSelect = (v: string) => {
     if (!item) return;
@@ -53,29 +59,53 @@ export const NormalizeDatasetItemLabel: FC<Params> = ({ datasetUid, itemUid }) =
       borderTop="1px solid"
       borderColor="icon.disabled"
     >
-      <Box flex="1 1 40%">
+      <Box flex="1 1 30%">
         <OstCheckbox
-          defaultChecked={item?.isActive}
-          onChange={() => {
-            handleIsActiveCheck();
+          isChecked={item?.isActive}
+          onChange={(e) => {
+            handleIsActiveCheck(e.target.checked);
           }}
         >
           {item?.rowLabel}
         </OstCheckbox>
       </Box>
-      <Flex flex="1 1 60%">
-        <Box p={4}>
+      <Flex flex="1 1 70%">
+        <Flex p={4} flex="0 0 20em" justifyContent="flex-end">
+          {isLabelOriginal && (
+            <Flex
+              alignItems="center"
+              px={4}
+              py={1}
+              border="3px solid"
+              borderColor="information.bg.error"
+              borderRadius="3em"
+              cursor="default"
+            >
+              <InfoOutlineIcon color="information.bg.error" mr={2} />
+              <Text color="information.bg.error" whiteSpace="nowrap">
+                独自項目です
+              </Text>
+            </Flex>
+          )}
           <Text
+            ml={2}
             px={4}
             py={2}
-            bg={isLabelOriginal ? 'information.bg.alert' : 'information.bg.disabled'}
+            color={isLabelRecommend && isLabelOriginal ? 'white' : 'inherit'}
+            bg={
+              isLabelRecommend
+                ? 'icon.active'
+                : isLabelOriginal
+                ? 'information.bg.alert'
+                : 'information.bg.disabled'
+            }
             borderRadius="3em"
             whiteSpace="nowrap"
             cursor="default"
           >
-            {isLabelOriginal ? '項目名を選択' : '一致しました'}
+            {isLabelRecommend ? '差し替え済み' : isLabelOriginal ? '項目名を選択' : '一致しました'}
           </Text>
-        </Box>
+        </Flex>
         <OstSelect
           value={item?.normalizedLabel || ''}
           onChange={(e) => handleSelect(e.target.value)}

--- a/webclient/src/hooks/useDataset.ts
+++ b/webclient/src/hooks/useDataset.ts
@@ -193,7 +193,7 @@ export const useGetDatasetWithNewItems = (params: { datasetUid: string }) => {
   });
   const items = [...additionalItems, ...originalItems];
   const mergedItems: Dataset.Item[] = Object.values(
-    items.reduce((acc, cur) => Object.assign(acc, { [cur.normalizedLabel]: cur }), {})
+    items.reduce((acc, cur) => Object.assign(acc, { [cur.rowLabel]: cur }), {})
   );
   const labelList = itemsListOfPublicFacilities.map((item) => item.label); // TODO: itemsListOfPublicFacilitiesのベタうちなので、paramか何かに置き換える
   const sortedItems = mergedItems.sort((x: Dataset.Item, y: Dataset.Item) => {
@@ -221,8 +221,10 @@ export const useGetDatasetWithNewItems = (params: { datasetUid: string }) => {
           const singleCell = rowCells.find((cell) => cell.itemUid === item.uid);
           if (singleCell && item.normalizedLabel) {
             singleRow[item.normalizedLabel] = singleCell.editedValue || singleCell.rowValue || '';
+          } else if (singleCell && !item.normalizedLabel && item.rowLabel) {
+            singleRow[item.rowLabel] = singleCell.editedValue || singleCell.rowValue || '';
           } else {
-            singleRow[item.rowLabel!] = ''; // TODO: 懸案: オリジナル項目があった場合、空文字に変換されてしまう
+            singleRow[item.rowLabel!] = '';
           }
         }
         dataset.push(singleRow);

--- a/webclient/src/theme/foundations/colors.ts
+++ b/webclient/src/theme/foundations/colors.ts
@@ -30,6 +30,7 @@ const colors = {
   },
   information: {
     bg: {
+      error: '#B1012B',
       alert: '#FFDE6A',
       active: 'rgba(115, 205, 255, 0.4)',
       disabled: 'rgba(204, 204, 204, 0.4)',


### PR DESCRIPTION
close #125 
close #126 

- normalize-label画面
  - デフォルトチェックの処理を追加
  - 独自項目・レコメンドの表示を追加
- data-editor画面
  - ステップ３でチェックを入れた項目のみ表示するように修正
  - ダウンロードcsvに独自項目を残すように修正