### PR TITLE
ファイル選択イベントが2回発生しないように修正

### DIFF
--- a/webclient/src/features/upload/routes/FileUpload.tsx
+++ b/webclient/src/features/upload/routes/FileUpload.tsx
@@ -65,7 +65,6 @@ export const FileUpload: FC = () => {
             borderRadius={20}
             bg="information.bg.active"
             textAlign="center"
-            as="label"
             display="block"
             cursor="pointer"
             fontSize="xl"


### PR DESCRIPTION
close #104

STEP1「ここに、CSVファイルをドロップしてください」と表示されている箇所を直接クリックした際に、ファイル選択画面が一度だけ表示されるように修正

（Windows + Chromeの環境で動作確認しました）