### PR TITLE
モーダルのボタンのアイコンのずれを修正

### DIFF
--- a/webclient/src/components/Elements/OstButton/OstButton.tsx
+++ b/webclient/src/components/Elements/OstButton/OstButton.tsx
@@ -3,7 +3,8 @@ import { Button, forwardRef, ButtonProps } from '@chakra-ui/react';
 
 export type OstButtonProps = {
   isDisabled?: boolean;
-  icon?: React.ReactElement;
+  iconLeft?: React.ReactElement;
+  iconRight?: React.ReactElement;
   size: 'L' | 'S';
   children?: React.ReactNode;
   view: 'button' | 'skeleton' | 'icon-only';
@@ -30,7 +31,7 @@ export const OstButton = forwardRef<ButtonProps & OstButtonProps, 'button'>((pro
   }
 
   return (
-    <Button ref={ref} variant={variant} leftIcon={props.icon} {...props}>
+    <Button ref={ref} variant={variant} leftIcon={props.iconLeft} rightIcon={props.iconRight} {...props}>
       {props.children}
     </Button>
   );

--- a/webclient/src/features/data-editor/routes/DataEditor.tsx
+++ b/webclient/src/features/data-editor/routes/DataEditor.tsx
@@ -98,7 +98,7 @@ export const DataEditor: FC = () => {
             <OstButton
               view="skeleton"
               size="L"
-              icon={<Avatar bg="bg.active" size="md" p="12px" icon={<DownloadIcon />} />}
+              iconLeft={<Avatar bg="bg.active" size="md" p="12px" icon={<DownloadIcon />} />}
               onClick={() => exportCsv(datasetWithNewItems)}
             >
               ダウンロード
@@ -140,13 +140,14 @@ export const DataEditor: FC = () => {
             <OstButton
               size="L"
               view="button"
+              iconRight={<Icon as={DownloadIcon} w={6} h={6}/>}
               onClick={() => {
                 onDownloadClose();
                 exportCsv(datasetWithNewItems); // 完成したcsvのダウンロード
                 onPreviewOpen();
               }}
             >
-              作業ファイルをダウンロード<DownloadIcon w={6} h={6} ml={4} />
+              作業ファイルをダウンロード
             </OstButton>
           </ModalFooter>
         </ModalContent>
@@ -177,8 +178,9 @@ export const DataEditor: FC = () => {
               <OstButton
                 size="L"
                 view="button"
+                iconRight={<Icon as={MdOutlineMap} w={6} h={6}/>}
               >
-                マップでプレビュー確認<Icon as={MdOutlineMap} w={6} h={6} ml={4} />
+                マップでプレビュー確認
               </OstButton>
             </Link>
           </ModalFooter>

--- a/webclient/src/features/test/routes/test.tsx
+++ b/webclient/src/features/test/routes/test.tsx
@@ -29,16 +29,16 @@ export const Test = () => {
       <OstButton view="button" size="L" isDisabled={true}>
         ボタン
       </OstButton>
-      <OstButton view="button" size="L" icon={<Icon as={MdFolder} />}>
+      <OstButton view="button" size="L" iconLeft={<Icon as={MdFolder} />}>
         ボタン
       </OstButton>
-      <OstButton view="button" size="L" isDisabled={true} icon={<Icon as={MdFolder} />}>
+      <OstButton view="button" size="L" isDisabled={true} iconLeft={<Icon as={MdFolder} />}>
         ボタン
       </OstButton>
       <OstButton
         view="skeleton"
         size="L"
-        icon={<Avatar bg="bg.active" size="md" p="12px" icon={<Icon as={MdFolder} />} />}
+        iconLeft={<Avatar bg="bg.active" size="md" p="12px" icon={<Icon as={MdFolder} />} />}
       >
         ボタン
       </OstButton>
@@ -46,20 +46,20 @@ export const Test = () => {
         view="skeleton"
         size="L"
         isDisabled={true}
-        icon={<Avatar size="md" p="12px" icon={<Icon as={MdFolder} />} />}
+        iconLeft={<Avatar size="md" p="12px" icon={<Icon as={MdFolder} />} />}
       >
         ボタン
       </OstButton>
       <OstButton
         view="icon-only"
         size="L"
-        icon={<Avatar bg="bg.active" size="md" p="12px" icon={<Icon as={MdFolder} />} />}
+        iconLeft={<Avatar bg="bg.active" size="md" p="12px" icon={<Icon as={MdFolder} />} />}
       />
       <OstButton
         view="icon-only"
         size="L"
         isDisabled={true}
-        icon={<Avatar size="md" p="12px" icon={<Icon as={MdFolder} />} />}
+        iconLeft={<Avatar size="md" p="12px" icon={<Icon as={MdFolder} />} />}
       />
       <OstButton view="button" size="S">
         ボタン
@@ -67,16 +67,16 @@ export const Test = () => {
       <OstButton view="button" size="S" isDisabled={true}>
         ボタン
       </OstButton>
-      <OstButton view="button" size="S" icon={<Icon as={MdSettings} />}>
+      <OstButton view="button" size="S" iconLeft={<Icon as={MdSettings} />}>
         ボタン
       </OstButton>
-      <OstButton view="button" size="S" isDisabled={true} icon={<Icon as={MdSettings} />}>
+      <OstButton view="button" size="S" isDisabled={true} iconLeft={<Icon as={MdSettings} />}>
         ボタン
       </OstButton>
       <OstButton
         view="skeleton"
         size="S"
-        icon={<Avatar bg="bg.active" size="sm" icon={<Icon as={MdSettings} />} />}
+        iconLeft={<Avatar bg="bg.active" size="sm" icon={<Icon as={MdSettings} />} />}
       >
         ボタン
       </OstButton>
@@ -84,20 +84,20 @@ export const Test = () => {
         view="skeleton"
         size="S"
         isDisabled={true}
-        icon={<Avatar size="sm" icon={<Icon as={MdSettings} />} />}
+        iconLeft={<Avatar size="sm" icon={<Icon as={MdSettings} />} />}
       >
         ボタン
       </OstButton>
       <OstButton
         view="icon-only"
         size="S"
-        icon={<Avatar bg="bg.active" size="sm" icon={<Icon as={MdSettings} />} />}
+        iconLeft={<Avatar bg="bg.active" size="sm" icon={<Icon as={MdSettings} />} />}
       />
       <OstButton
         view="icon-only"
         size="S"
         isDisabled={true}
-        icon={<Avatar size="sm" icon={<Icon as={MdSettings} />} />}
+        iconLeft={<Avatar size="sm" icon={<Icon as={MdSettings} />} />}
       />
       <OstLink url="https://www.google.com">リンク</OstLink>
       <OstLink url="https://www.google.com" icon={<Icon as={MdSupervisedUserCircle} />}>


### PR DESCRIPTION
モーダルのボタンのアイコンが下にずれてしまっていたので、中心に来るように修正しました。

![image](https://user-images.githubusercontent.com/36665200/198872017-1044145b-2aa6-440d-90f6-dbf7d393b315.png)

![image](https://user-images.githubusercontent.com/36665200/198872040-ba4fa414-6f19-45c9-b5fa-b942e36b7195.png)

変更点

- モーダルのボタンのアイコンレイアウトを修正
- コンポーネント `OstButton` に属性 `iconLeft`, `iconRight` を追加し、アイコン位置を調整できるように変更
  - 既存の `icon` は `iconLeft` に対応