### PR TITLE
csvアップロードから直接マップを表示するための画面を作成

### DIFF
--- a/webclient/src/components/Layout/BoxLayout.tsx
+++ b/webclient/src/components/Layout/BoxLayout.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+import { Head } from '../Head';
+
+type BoxLayoutProps = {
+  children: React.ReactNode;
+  headingText: string;
+  pageTitle: string;
+};
+
+export const BoxLayout = (props: BoxLayoutProps) => {
+  return (
+    <>
+      <Head title={props.pageTitle} />
+      <Box w="100%" maxW={1280} mx="auto" py={20}>
+        <Box mx={4} borderRadius={20} bg="white">
+          <Box textStyle="h1" p={10}>
+            {/* 2022/10/2時点 chakra-uiのバグ？でHeadingに直接textStyleを指定できない*/}
+            <Heading as="h1" fontSize="inherit" fontWeight="inherit" textAlign="center">
+              {props.headingText}
+            </Heading>
+          </Box>
+          <Box p={10} pt={0}>
+            {props.children}
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+};

--- a/webclient/src/components/Layout/index.ts
+++ b/webclient/src/components/Layout/index.ts
@@ -1,3 +1,4 @@
 export * from './MainLayout';
 export * from './ContentLayout';
 export * from './StepLayout';
+export * from './BoxLayout';

--- a/webclient/src/features/home/routes/Home.tsx
+++ b/webclient/src/features/home/routes/Home.tsx
@@ -1,11 +1,20 @@
-import { Box } from '@chakra-ui/react';
+import { Avatar, Box, Flex } from '@chakra-ui/react';
 import { ContentLayout } from '../../../components/Layout';
-import { OstLink } from '../../../components/Elements/OstLink';
+import { OstLink, OstNavLink } from '../../../components/Elements/OstLink';
 import { HomeSavedDatasetList } from '../../../components/Home';
+import { ArrowForwardIcon } from '@chakra-ui/icons';
 export const Home = () => {
   return (
     <ContentLayout title="ホーム">
       <Box>ホーム</Box>
+      <Flex mt={4} justifyContent="flex-end">
+        <OstNavLink
+          to="/upload-file-for-map"
+          iconRight={<Avatar size="md" p="12px" icon={<ArrowForwardIcon />} />}
+        >
+          CSVを元にMapを表示する
+        </OstNavLink>
+      </Flex>
       <HomeSavedDatasetList />
       <Box w="300px">
         <OstLink to="/upload-file">はじめる（CSV選択画面）</OstLink>

--- a/webclient/src/features/upload-for-map/index.ts
+++ b/webclient/src/features/upload-for-map/index.ts
@@ -1,0 +1,1 @@
+export * from './routes/FileUploadForMap';

--- a/webclient/src/features/upload-for-map/routes/FileUploadForMap.tsx
+++ b/webclient/src/features/upload-for-map/routes/FileUploadForMap.tsx
@@ -1,0 +1,183 @@
+import { Avatar, Box, Center, Code, Flex, InputGroup, Spinner, Text } from '@chakra-ui/react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { BoxLayout } from '../../../components/Layout';
+import { OstNavLink } from '../../../components/Elements/OstLink';
+import { ArrowForwardIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import { TbFileDescription } from 'react-icons/tb';
+import { useDropzone } from 'react-dropzone';
+import parser, { ParseResult } from 'papaparse';
+import { useGetItemsUnnormalized, useImportDataset } from '../../../hooks/useDataset';
+import { utilCharEncoding } from 'opendatatool-datamanager';
+import { useSetRecoilState } from 'recoil';
+import { datasetItemListSelector } from '../../../stores/dataset';
+
+export const FileUploadForMap: FC = () => {
+  const [csvName, setCsvName] = useState<string>();
+  const [isFilesMultiple, setIsFilesMultiple] = useState<boolean>(false);
+  const [datasetUid, setDatasetUid] = useState<string>();
+  const [uploadedFileBuffer, setUploadedFileBuffer] = useState<{
+    fileName: string;
+    buffer: Buffer;
+  } | null>(null);
+  const [charCodeConvertedData, setCharCodeConvertedData] = useState<string>();
+  const [isFinishedProgress, setIsFinishedProgress] = useState<boolean>(false);
+  const importRowData = useImportDataset();
+  const itemsUnnormalized = useGetItemsUnnormalized({ datasetUid: datasetUid || '' });
+  const setDatasetItem = useSetRecoilState(
+    datasetItemListSelector({ datasetUid: datasetUid || '' })
+  );
+
+  const onDrop = useCallback((csvFile: any) => {
+    csvFile.forEach((file: any) => {
+      try {
+        const reader = new FileReader();
+
+        reader.onload = () => {
+          if (csvFile.length >= 2) {
+            setIsFilesMultiple(true);
+            return;
+          }
+          setIsFilesMultiple(false);
+          const rowData: any = reader.result;
+          setUploadedFileBuffer({ fileName: file.name, buffer: rowData });
+          setCsvName(file.name);
+        };
+        reader.readAsArrayBuffer(file);
+      } catch (error) {
+        return;
+      }
+    });
+  }, []);
+
+  const { getRootProps, getInputProps } = useDropzone({ accept: { 'text/csv': ['.csv'] }, onDrop });
+
+  useEffect(() => {
+    if (uploadedFileBuffer) {
+      setCharCodeConvertedData(utilCharEncoding.toString(uploadedFileBuffer.buffer));
+    }
+  }, [uploadedFileBuffer]);
+
+  useEffect(() => {
+    if (charCodeConvertedData && uploadedFileBuffer) {
+      try {
+        const rowDataObject: ParseResult<any> = parser.parse(charCodeConvertedData, {
+          header: true,
+        });
+        const rowHeaders = rowDataObject.meta.fields;
+        if (!rowHeaders) throw new Error('file is not selected');
+        const importedDatasetUid = importRowData({
+          datasetName: uploadedFileBuffer.fileName,
+          headers: rowHeaders,
+          rowDatas: rowDataObject.data,
+        });
+        setDatasetUid(importedDatasetUid);
+      } catch (error) {
+        return;
+      }
+    }
+  }, [charCodeConvertedData, uploadedFileBuffer]);
+
+  useEffect(() => {
+    if (itemsUnnormalized.length > 0) {
+      setDatasetItem(itemsUnnormalized);
+      setIsFinishedProgress(true);
+    }
+  }, [datasetUid, JSON.stringify(itemsUnnormalized)]);
+
+  return (
+    <BoxLayout
+      pageTitle="CSVアップロード"
+      headingText={
+        !csvName
+          ? 'CSVファイルをアップロードしてください'
+          : '以下のCSVファイルがアップロードされました'
+      }
+    >
+      {isFilesMultiple && (
+        <Flex alignItems="center" px={6} py={4} mb={10} bg="information.bg.alert" borderRadius={8}>
+          <InfoOutlineIcon />
+          <Text ml={6}>CSVファイルのアップロードは一つずつ行ってください</Text>
+        </Flex>
+      )}
+      {!csvName && (
+        <Center>検証を行いたいファイルを下記の枠内にドラッグ＆ドロップしてください</Center>
+      )}
+      {!csvName ? (
+        <div {...getRootProps()}>
+          <Box
+            p={20}
+            mt={10}
+            border="4px dashed"
+            borderColor="icon.active"
+            borderRadius={20}
+            bg="information.bg.active"
+            textAlign="center"
+            display="block"
+            cursor="pointer"
+            fontSize="xl"
+            fontWeight="bold"
+            color="icon.active"
+          >
+            <Center py={5}>
+              <TbFileDescription size={50} />
+            </Center>
+            ここに、CSVファイルをドロップしてください
+            <InputGroup>
+              <input {...getInputProps()} />
+            </InputGroup>
+          </Box>
+        </div>
+      ) : (
+        <Box
+          p={20}
+          mt={4}
+          borderRadius={20}
+          bg="information.bg.disabled"
+          textAlign="center"
+          as="label"
+          display="block"
+          cursor="pointer"
+          fontSize="xl"
+          fontWeight="bold"
+          color="icon.active"
+        >
+          <Center py={5}>
+            <TbFileDescription size={50} />
+          </Center>
+          {csvName}
+        </Box>
+      )}
+      {uploadedFileBuffer && !isFinishedProgress && (
+        <Flex
+          alignItems="center"
+          px={6}
+          py={4}
+          my={6}
+          borderRadius={8}
+          textStyle="navigationLarge"
+          bg="information.bg.alert"
+          color="body.text"
+        >
+          <Spinner mr={6} w={5} h={5} />
+          <Text>マップを表示する準備をしています</Text>
+        </Flex>
+      )}
+      {datasetUid && isFinishedProgress && (
+        <Flex mt={5} justifyContent="flex-end">
+          <Text display="inline-block" bg="information.bg.active" borderRadius="3em" px={8} py={2}>
+            マップを表示する準備が終わりました
+          </Text>
+        </Flex>
+      )}
+      <Flex mt={4} justifyContent="flex-end">
+        <OstNavLink
+          to={`/${datasetUid}/map`}
+          isDisabled={!datasetUid || !isFinishedProgress}
+          iconRight={<Avatar size="md" p="12px" icon={<ArrowForwardIcon />} />}
+        >
+          マップを表示する
+        </OstNavLink>
+      </Flex>
+    </BoxLayout>
+  );
+};

--- a/webclient/src/hooks/useDataset.ts
+++ b/webclient/src/hooks/useDataset.ts
@@ -344,3 +344,22 @@ export const useRemoveDatasetFromLocalstorage = (params: { datasetUid: string })
 
   return { removeFromLocalstorage, executing };
 };
+
+export const useGetItemsUnnormalized = (params: { datasetUid: string }) => {
+  const [datasetItems, setDatasetItems] = useState<Dataset.Item[]>([]);
+  const items = useRecoilValue(datasetItemListSelector(params));
+
+  useEffect(() => {
+    if (items.length > 0) {
+      const parseDataset = () => {
+        const normalizedItems: Dataset.Item[] = items.map((item) => {
+          return { ...item, normalizedLabel: item.rowLabel };
+        });
+        setDatasetItems(normalizedItems);
+      };
+      parseDataset();
+    }
+  }, [items]);
+
+  return datasetItems;
+};

--- a/webclient/src/routes/public.tsx
+++ b/webclient/src/routes/public.tsx
@@ -4,6 +4,7 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { MainLayout } from '../components/Layout';
 import { MapEditorTest } from '../features/map-editor-test';
 import { FileUpload } from '../features/upload';
+import { FileUploadForMap } from '../features/upload-for-map';
 import { lazyImport } from '../utils/lazyImport';
 
 const { Home } = lazyImport(() => import('../features/home'), 'Home');
@@ -34,6 +35,7 @@ export const publicRoutes = [
     children: [
       { path: '/', element: <Home /> },
       { path: '/upload-file', element: <FileUpload /> },
+      { path: '/upload-file-for-map', element: <FileUploadForMap /> },
       { path: '/auto-convert', element: <AutoConvert /> },
       { path: '/:dataset_uid/normalize-label', element: <NormalizeLabel /> },
       { path: '/:dataset_uid/data-editor', element: <DataEditor /> },


### PR DESCRIPTION
close #148 

`webclient/src/features/upload/routes/FileUpload.tsx` を複製して `webclient/src/features/upload-for-map/routes/FileUploadForMap.tsx` を作成し、文字コード変換とnormalizedLabelにrowLabelを当てる処理をするようにしました。

![CSVアップロード-Bulletproof-React](https://user-images.githubusercontent.com/14883063/198929500-6de9cfc5-ea10-4221-ac80-8144e4b8ac83.png)

![CSVアップロード-Bulletproof-React (1)](https://user-images.githubusercontent.com/14883063/198929516-60be90b5-7bf4-4e07-aaa4-026ed0bf44ac.png)

![CSVアップロード-Bulletproof-React (2)](https://user-images.githubusercontent.com/14883063/198929530-0fe07b97-315e-4ce3-b123-6c6054bfd7d9.png)
