### PR TITLE
トップ画面のスタイルを整える

### DIFF
--- a/webclient/src/components/Home/Description.tsx
+++ b/webclient/src/components/Home/Description.tsx
@@ -26,8 +26,7 @@ const StepCard = ({ children, title, subTitle }: StepCardProps) => {
         color="white"
         px={6}
         py={4}
-        // HACK: 上側だけ角を丸くする
-        borderRadius="8px 8px 0 0"
+        borderTopRadius={8}
       >
         <Text fontSize="md">
           {subTitle}

--- a/webclient/src/components/Home/Description.tsx
+++ b/webclient/src/components/Home/Description.tsx
@@ -1,0 +1,198 @@
+import { MdOutlineMap } from 'react-icons/md';
+import { Link } from 'react-router-dom';
+import { Avatar, Box, Flex, Heading, ListItem, Stack, Text, UnorderedList } from '@chakra-ui/react';
+import { ArrowForwardIcon, Icon, InfoOutlineIcon } from '@chakra-ui/icons';
+import { OstNavLink } from '../Elements/OstLink';
+import { OstButton } from '../Elements/OstButton';
+
+type StepCardProps = {
+  children: React.ReactNode;
+  title: React.ReactNode;
+  subTitle: string;
+};
+
+const StepCard = ({ children, title, subTitle }: StepCardProps) => {
+  return (
+    <Stack
+      alignItems="left"
+      borderRadius={8}
+      textStyle="navigationLarge"
+      background="white"
+      // 各要素の幅を均等にするために指定
+      width="100%"
+    >
+      <Stack
+        background="#42667A"
+        color="white"
+        px={6}
+        py={4}
+        // HACK: 上側だけ角を丸くする
+        borderRadius="8px 8px 0 0"
+      >
+        <Text fontSize="md">
+          {subTitle}
+        </Text>
+        <Heading size="md">
+          {title}
+        </Heading>
+      </Stack>
+      <Stack
+        px={6}
+        py={4}
+      >
+        {children}
+      </Stack>
+    </Stack>
+  )
+}
+
+export const Description = () => {
+  return (
+    <>
+      <Stack
+        alignItems="left"
+        px={6}
+        py={6}
+        my={6}
+        borderRadius={8}
+        spacing={4}
+        textStyle="navigationLarge"
+        background="white"
+      >
+        <Heading size="lg">
+          このツールについて
+        </Heading>
+        <Text fontSize="md">
+          オープンデータへの取組により、国民参加・官民協働の推進を通じた諸課題の解決、経済活性化、行政の高度化・効率化等が期待されています。
+          しかし、自治体が公開しているオープンデータは増えてきているものの、機械判読性が高くフォーマットに沿った形で公開されているデータが少ないことが、活用する際の課題となっています。
+          その課題を解決するため、データ作成のための支援ツールを開発しました。
+        </Text>
+        <Text fontSize="md">
+          このツールでは、政府が公開している「推奨データセット」で指定されているものを対象とし、4つのステップでデータ内容を確認し修正を行います。
+          全てのステップが完了するとマップが表示され、データが活用できる状態となっているか確認ができるツールとなっています。
+        </Text>
+        <Flex
+          alignItems="center"
+          px={6}
+          py={4}
+          bg={'information.bg.alert'}
+          borderRadius={8}
+        >
+          <InfoOutlineIcon />
+          <Text ml={6} fontSize="md">
+            現在、試験段階（プロトタイプ）のため、「推奨データセット」の「公共施設一覧」にのみ対応しております。
+          </Text>
+        </Flex>
+      </Stack>
+      <Flex
+        justifyContent="space-between"
+        my={6}
+        gap={6}
+      >
+        <StepCard
+          title={<>CSVファイルを<br />アップロードします</>}
+          subTitle="ステップ1"
+        >
+          <Text fontSize="md">
+            ご自身のパソコンにある、CSVファイルをアップロードします。
+          </Text>
+          <Text fontSize="md" pt={4}>
+            <b>ご注意ください</b>
+          </Text>
+          <Text fontSize="md">
+            Excel（.xls/.xlsx）のファイルはアップロード対応していませんので、Excelファイルの場合はファイル形式を「CSV UTF-8(コンマ区切り)(.csv)」で保存した状態で、アップロードしてください。
+          </Text>
+        </StepCard>
+        <StepCard
+          title={<>データを<br />自動変換します</>}
+          subTitle="ステップ2"
+        >
+          <Text fontSize="md">
+            アップロードされたCSVデータを、自動変換します。
+          </Text>
+          <Box fontSize="md" pl={4}>
+            <UnorderedList>
+              <ListItem>文字コード</ListItem>
+              <ListItem>半角全角</ListItem>
+              <ListItem>必須項目の確認</ListItem>
+            </UnorderedList>
+          </Box>
+          <Text fontSize="md">
+          上記のデータチェックが自動で行われます。各変換のローディングが完了するまでお待ちください。
+          </Text>
+        </StepCard>
+        <StepCard
+          title={<>データ項目名を<br />整合させてください</>}
+          subTitle="ステップ3"
+        >
+          <Text fontSize="md">
+            政府が公開している「推奨データセット」のデータ項目名と整合させます。
+          </Text>
+          <Text fontSize="md">
+            各項目名と、アップロードされたCSVの項目名が一致していることを確認してください。
+          </Text>
+          <Text fontSize="md">
+            独自の項目として残す場合は、項目リストにチェックを入れてください。
+          </Text>
+        </StepCard>
+        <StepCard
+          title={<>データ形式を<br />確認してください</>}
+          subTitle="ステップ4"
+        >
+          <Text fontSize="md">
+            データ形式確認を行います。項目名別に、細かく修正ポイントが表示されます。
+          </Text>
+          <Text fontSize="md">
+            修正が進むと、完了ボタンが押せるようになります。
+          </Text>
+          <Text fontSize="md">
+            このステップまでに修正されたデータ（CSV）をダウンロードすることができるようになり、マップ表示が行えます。
+          </Text>
+        </StepCard>
+      </Flex>
+      <Flex
+        justifyContent="center"
+        my={6}
+      >
+        {/* NOTE: 見た目を塗りつぶしたボタンにするため、OstNavLinkではなくOstButtonを使用 */}
+        <Link to="/upload-file">
+          <OstButton
+            size="L"
+            view="button"
+            iconRight={<Icon as={ArrowForwardIcon} w={6} h={6}/>}
+          >
+            ステップ1からはじめる
+          </OstButton>
+        </Link>
+      </Flex>
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        px={6}
+        py={4}
+        my={2}
+        borderRadius={8}
+        textStyle="navigationLarge"
+        background="white"
+      >
+        <Stack
+          alignItems="left"
+        >
+          <Heading size="md">
+            マップ表示のみ試したい方
+          </Heading>
+          <Text fontSize="md">
+            作成されたデータ（CSV）をアップロードすることでマップ表示が行えます。
+          </Text>
+        </Stack>
+        <OstNavLink
+          to="/upload-file-for-map"
+          iconRight={<Avatar size="md" p="12px" icon={<MdOutlineMap />} />}
+          mr={8}
+        >
+          マップ表示を行ってみる
+        </OstNavLink>
+      </Flex>
+    </>
+  );
+}

--- a/webclient/src/components/Home/SavedDatasetList.tsx
+++ b/webclient/src/components/Home/SavedDatasetList.tsx
@@ -1,13 +1,50 @@
 import { Icon } from '@chakra-ui/icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/table';
-import { Box, Flex, Text } from '@chakra-ui/react';
-import { FC } from 'react';
+import { Avatar, Box, Flex, Heading, Text } from '@chakra-ui/react';
+import { FC, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { MdDeleteOutline, MdModeEditOutline, MdOutlineMap, MdOutlineTextSnippet } from "react-icons/md";
 import { useRecoilValue } from 'recoil';
 import { useRemoveDatasetFromLocalstorage } from '../../hooks/useDataset';
 import { datasetListSelector } from '../../stores/dataset';
 import { OstButton } from '../Elements/OstButton';
+import { OstNavLink } from '../Elements/OstLink';
+
+const RemoveAllButton: FC = () => {
+  const datasets = useRecoilValue(datasetListSelector);
+  // HACK: ループ処理で各datasetにuseRemoveDatasetFromLocalstorageを定義することができないため、1要素ずつ削除
+  // (関数コンポーネント内のフックの個数が動的に変化するとReactがクラッシュするため https://ja.reactjs.org/docs/hooks-rules.html)
+  const [deleting, setDeleting] = useState(false);
+  // 先頭のdatasetを削除する関数
+  const { removeFromLocalstorage } = useRemoveDatasetFromLocalstorage({datasetUid: String(datasets[0]?.uid)});
+
+  useEffect(() => {
+    // HACK: 以下のループにより、要素を逐次的にすべて削除
+    // (先頭要素を削除 → stateが更新され再レンダリング → removeFromLocalstorageの対象が「先頭要素削除後のdatasetsの先頭(=次の要素)」になる
+    // → useEffect実行 → 先頭要素削除)
+
+    if (datasets.length <= 0) {
+      setDeleting(false);
+      return;
+    }
+
+    if (deleting) {
+      removeFromLocalstorage();
+    }
+  });
+
+  return (
+    <OstNavLink
+      size="S"
+      onClick={() => setDeleting(true)}
+      // <Avatar size="md" p="12px" icon={<MdDeleteOutline />} />
+      iconRight={<Avatar size="md" p="12px" icon={<MdDeleteOutline />} />}
+      mx={1}
+    >
+      データリストのクリア
+    </OstNavLink>
+  );
+};
 
 type RemoveButtonProps = {
   datasetUid: string;
@@ -36,58 +73,64 @@ export const HomeSavedDatasetList: FC = () => {
   };
 
   return (
-    <Table variant='striped' colorScheme='gray'>
-      <Thead>
-        <Tr>
-          <Th visibility="hidden">ファイル名</Th>
-          <Th visibility="hidden">ID</Th>
-          <Th visibility="hidden"></Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        {datasets
-          .filter((d) => d)
-          .map((dataset) => (
-            <Tr key={dataset?.uid}>
-              <Td>
-                <Flex align="center" >
-                  <Icon as={MdOutlineTextSnippet} w={6} h={6} mr={2}/><Text>{dataset?.datasetName}</Text>
-                </Flex>
-              </Td>
-              <Td>
-                <Flex align="center">
-                  {/* NOTE: 文字を等幅にし全体の長さを揃えるためmonospaceを使用 */}
-                  {/* TODO: 別箇所でも同様のデザインが必要になったらElement化 */}
-                  <Box px={3} py={1} fontFamily="monospace, serif" background="dimgray" color="white" borderRadius="10px 0 0 10px">ID</Box>
-                  <Box px={3} py={1} fontFamily="monospace, serif" background="lightgray" borderRadius="0 10px 10px 0">{dataset?.uid}</Box>
-                </Flex>
-              </Td>
-              <Td>
-                <Link to={`/${dataset?.uid}/map`}>
-                  <OstButton
-                    size="S"
-                    view="button"
-                    iconRight={<Icon as={MdOutlineMap} w={5} h={5}/>}
-                    mx={1}
-                  >
-                    マップ表示
-                  </OstButton>
-                </Link>
-                <Link to={`/${dataset?.uid}/data-editor`}>
-                  <OstButton
-                    size="S"
-                    view="button"
-                    iconRight={<Icon as={MdModeEditOutline} w={5} h={5}/>}
-                    mx={1}
-                  >
-                    編集
-                  </OstButton>
-                </Link>
-                <RemoveButton datasetUid={String(dataset?.uid)} />
-              </Td>
-            </Tr>
-          ))}
-      </Tbody>
-    </Table>
+    <>
+      <Heading size="lg" my={4}>データリスト</Heading>
+      <Flex justifyContent="right">
+        <RemoveAllButton/>
+      </Flex>
+      <Table variant='striped' colorScheme='gray'>
+        <Thead>
+          <Tr>
+            <Th visibility="hidden">ファイル名</Th>
+            <Th visibility="hidden">ID</Th>
+            <Th visibility="hidden"></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {datasets
+            .filter((d) => d)
+            .map((dataset) => (
+              <Tr key={dataset?.uid}>
+                <Td>
+                  <Flex align="center" >
+                    <Icon as={MdOutlineTextSnippet} w={6} h={6} mr={2}/><Text>{dataset?.datasetName}</Text>
+                  </Flex>
+                </Td>
+                <Td>
+                  <Flex align="center">
+                    {/* NOTE: 文字を等幅にし全体の長さを揃えるためmonospaceを使用 */}
+                    {/* TODO: 別箇所でも同様のデザインが必要になったらElement化 */}
+                    <Box px={3} py={1} fontFamily="monospace, serif" background="dimgray" color="white" borderRadius="10px 0 0 10px">ID</Box>
+                    <Box px={3} py={1} fontFamily="monospace, serif" background="lightgray" borderRadius="0 10px 10px 0">{dataset?.uid}</Box>
+                  </Flex>
+                </Td>
+                <Td>
+                  <Link to={`/${dataset?.uid}/map`}>
+                    <OstButton
+                      size="S"
+                      view="button"
+                      iconRight={<Icon as={MdOutlineMap} w={5} h={5}/>}
+                      mx={1}
+                    >
+                      マップ表示
+                    </OstButton>
+                  </Link>
+                  <Link to={`/${dataset?.uid}/data-editor`}>
+                    <OstButton
+                      size="S"
+                      view="button"
+                      iconRight={<Icon as={MdModeEditOutline} w={5} h={5}/>}
+                      mx={1}
+                    >
+                      編集
+                    </OstButton>
+                  </Link>
+                  <RemoveButton datasetUid={String(dataset?.uid)} />
+                </Td>
+              </Tr>
+            ))}
+        </Tbody>
+      </Table>
+    </>
   );
 };

--- a/webclient/src/components/Home/SavedDatasetList.tsx
+++ b/webclient/src/components/Home/SavedDatasetList.tsx
@@ -100,8 +100,8 @@ export const HomeSavedDatasetList: FC = () => {
                   <Flex align="center">
                     {/* NOTE: 文字を等幅にし全体の長さを揃えるためmonospaceを使用 */}
                     {/* TODO: 別箇所でも同様のデザインが必要になったらElement化 */}
-                    <Box px={3} py={1} fontFamily="monospace, serif" background="dimgray" color="white" borderRadius="10px 0 0 10px">ID</Box>
-                    <Box px={3} py={1} fontFamily="monospace, serif" background="lightgray" borderRadius="0 10px 10px 0">{dataset?.uid}</Box>
+                    <Box px={3} py={1} fontFamily="monospace, serif" background="dimgray" color="white" borderLeftRadius={10}>ID</Box>
+                    <Box px={3} py={1} fontFamily="monospace, serif" background="lightgray" borderRightRadius={10}>{dataset?.uid}</Box>
                   </Flex>
                 </Td>
                 <Td>

--- a/webclient/src/components/Home/SavedDatasetList.tsx
+++ b/webclient/src/components/Home/SavedDatasetList.tsx
@@ -1,6 +1,9 @@
+import { Icon } from '@chakra-ui/icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/table';
-import { FC, useEffect, useRef, useState } from 'react';
+import { Box, Flex, Text } from '@chakra-ui/react';
+import { FC } from 'react';
 import { Link } from 'react-router-dom';
+import { MdDeleteOutline, MdModeEditOutline, MdOutlineMap, MdOutlineTextSnippet } from "react-icons/md";
 import { useRecoilValue } from 'recoil';
 import { useRemoveDatasetFromLocalstorage } from '../../hooks/useDataset';
 import { datasetListSelector } from '../../stores/dataset';
@@ -24,6 +27,8 @@ export const HomeSavedDatasetList: FC = () => {
         view="button"
         onClick={() => removeFromLocalstorage()}
         isLoading={executing}
+        iconRight={<Icon as={MdDeleteOutline} w={5} h={5}/>}
+        mx={1}
       >
         削除
       </OstButton>
@@ -31,28 +36,51 @@ export const HomeSavedDatasetList: FC = () => {
   };
 
   return (
-    <Table>
+    <Table variant='striped' colorScheme='gray'>
       <Thead>
-        <Th>ID</Th>
-        <Th>ファイル名</Th>
-        <Th></Th>
+        <Tr>
+          <Th visibility="hidden">ファイル名</Th>
+          <Th visibility="hidden">ID</Th>
+          <Th visibility="hidden"></Th>
+        </Tr>
       </Thead>
       <Tbody>
         {datasets
           .filter((d) => d)
           .map((dataset) => (
             <Tr key={dataset?.uid}>
-              <Td>{dataset?.uid}</Td>
-              <Td>{dataset?.datasetName}</Td>
+              <Td>
+                <Flex align="center" >
+                  <Icon as={MdOutlineTextSnippet} w={6} h={6} mr={2}/><Text>{dataset?.datasetName}</Text>
+                </Flex>
+              </Td>
+              <Td>
+                <Flex align="center">
+                  {/* NOTE: 文字を等幅にし全体の長さを揃えるためmonospaceを使用 */}
+                  {/* TODO: 別箇所でも同様のデザインが必要になったらElement化 */}
+                  <Box px={3} py={1} fontFamily="monospace, serif" background="dimgray" color="white" borderRadius="10px 0 0 10px">ID</Box>
+                  <Box px={3} py={1} fontFamily="monospace, serif" background="lightgray" borderRadius="0 10px 10px 0">{dataset?.uid}</Box>
+                </Flex>
+              </Td>
               <Td>
                 <Link to={`/${dataset?.uid}/map`}>
-                  <OstButton size="S" view="button">
-                    マップ
+                  <OstButton
+                    size="S"
+                    view="button"
+                    iconRight={<Icon as={MdOutlineMap} w={5} h={5}/>}
+                    mx={1}
+                  >
+                    マップ表示
                   </OstButton>
                 </Link>
                 <Link to={`/${dataset?.uid}/data-editor`}>
-                  <OstButton size="S" view="button">
-                    データ編集
+                  <OstButton
+                    size="S"
+                    view="button"
+                    iconRight={<Icon as={MdModeEditOutline} w={5} h={5}/>}
+                    mx={1}
+                  >
+                    編集
                   </OstButton>
                 </Link>
                 <RemoveButton datasetUid={String(dataset?.uid)} />

--- a/webclient/src/components/Home/index.ts
+++ b/webclient/src/components/Home/index.ts
@@ -1,1 +1,2 @@
+export * from './Description';
 export * from './SavedDatasetList';

--- a/webclient/src/components/Layout/ContentLayout.tsx
+++ b/webclient/src/components/Layout/ContentLayout.tsx
@@ -10,9 +10,7 @@ export const ContentLayout = ({ children, title }: ContentLayoutProps) => {
   return (
     <>
       <Head title={title} />
-      <div>
-        <div>{children}</div>
-      </div>
+      <div>{children}</div>
     </>
   );
 };

--- a/webclient/src/components/Layout/ContentLayout.tsx
+++ b/webclient/src/components/Layout/ContentLayout.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Box, Heading } from '@chakra-ui/react';
 import { Head } from '../Head';
 
 type ContentLayoutProps = {
@@ -12,12 +11,6 @@ export const ContentLayout = ({ children, title }: ContentLayoutProps) => {
     <>
       <Head title={title} />
       <div>
-        <Box textStyle="h1" color="white" bg="black" px={8} py={4}>
-          {/* 2022/10/2時点 chakra-uiのバグ？でHeadingに直接textStyleを指定できない*/}
-          <Heading as="h1" fontSize="inherit" fontWeight="inherit">
-            {title}
-          </Heading>
-        </Box>
         <div>{children}</div>
       </div>
     </>

--- a/webclient/src/features/home/routes/Home.tsx
+++ b/webclient/src/features/home/routes/Home.tsx
@@ -1,23 +1,21 @@
-import { Avatar, Box, Flex } from '@chakra-ui/react';
+import { Box, Heading } from '@chakra-ui/react';
 import { ContentLayout } from '../../../components/Layout';
-import { OstLink, OstNavLink } from '../../../components/Elements/OstLink';
-import { HomeSavedDatasetList } from '../../../components/Home';
-import { ArrowForwardIcon } from '@chakra-ui/icons';
+import { HomeSavedDatasetList, Description } from '../../../components/Home';
 export const Home = () => {
   return (
     <ContentLayout title="ホーム">
-      <Box>ホーム</Box>
-      <Flex mt={4} justifyContent="flex-end">
-        <OstNavLink
-          to="/upload-file-for-map"
-          iconRight={<Avatar size="md" p="12px" icon={<ArrowForwardIcon />} />}
+      <Box mx={6}>
+        <Description />
+        <Box
+          background="white"
+          borderRadius={8}
+          my={6}
+          px={6}
+          py={6}
         >
-          CSVを元にMapを表示する
-        </OstNavLink>
-      </Flex>
-      <HomeSavedDatasetList />
-      <Box w="300px">
-        <OstLink to="/upload-file">はじめる（CSV選択画面）</OstLink>
+          <Heading size="lg" my={4}>データリスト</Heading>
+          <HomeSavedDatasetList />
+        </Box>
       </Box>
     </ContentLayout>
   );

--- a/webclient/src/features/home/routes/Home.tsx
+++ b/webclient/src/features/home/routes/Home.tsx
@@ -1,6 +1,7 @@
-import { Box, Heading } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { ContentLayout } from '../../../components/Layout';
 import { HomeSavedDatasetList, Description } from '../../../components/Home';
+
 export const Home = () => {
   return (
     <ContentLayout title="ホーム">
@@ -13,7 +14,6 @@ export const Home = () => {
           px={6}
           py={6}
         >
-          <Heading size="lg" my={4}>データリスト</Heading>
           <HomeSavedDatasetList />
         </Box>
       </Box>


### PR DESCRIPTION
トップ画面のスタイルを整え、説明文を追加しました。

![top1_created](https://user-images.githubusercontent.com/36665200/199353503-bcb49090-de8b-49ba-97bb-40c7ef65dbce.png)
![top2_created](https://user-images.githubusercontent.com/36665200/199353513-8837818f-2e94-4c43-a846-df0246392b37.png)


変更点

- ツールの説明を追加
- マップ表示のリンクを追加
- データリストのデザインを変更
- データリストの一括削除ボタンを追加

close #145 