### PR TITLE
自動変換ページで全角半角の変換を実施

### DIFF
--- a/datamanager/nodejs/index.ts
+++ b/datamanager/nodejs/index.ts
@@ -13,9 +13,11 @@ import { ItemValidatorNo } from './items/validator/no';
 import { ItemValidatorPoi } from './items/validator/poi';
 import { ItemValidatorRegname } from './items/validator/regname';
 import { ItemValidatorTime } from './items/validator/time';
+import { ItemFormatter2bytes2byte } from './items/formatter/2bytes2byte';
 
 const schemeValidator = new SchemeValidater();
 const itemLabelFormatter = new SchemeFormatterItemLabel();
+const item2bytes2byteFormatter = new ItemFormatter2bytes2byte();
 const validateRegionCode = new ItemValidatorRegcode();
 const validateTel = new ItemValidatorTel();
 const validateUrl = new ItemValidatorUrl();
@@ -33,6 +35,7 @@ const datasetListOfRecommendBasic = RECOMMEND_BASIC_DATASET_LIST;
 export {
   schemeValidator,
   itemLabelFormatter,
+  item2bytes2byteFormatter,
   validateRegionCode,
   validateTel,
   validateUrl,

--- a/datamanager/nodejs/items/formatter/2bytes2byte.test.ts
+++ b/datamanager/nodejs/items/formatter/2bytes2byte.test.ts
@@ -1,0 +1,47 @@
+import { ItemFormatter2bytes2byte } from './2bytes2byte';
+
+describe('items/formatter/2bytes2byte', () => {
+  const formatter = new ItemFormatter2bytes2byte();
+
+  test('全角数字が変換されているか', () => {
+    const data = [
+      {
+        都道府県コード又は市区町村コード: '１２３４５６',
+        名称_カナ: 'ﾃｽﾄ',
+        電話番号: '１２３－１２３',
+        緯度: '１２３．１２',
+        開始時間: '１２：００',
+      },
+    ];
+    const formatedData = formatter.format(data);
+    expect(formatedData.map((d) => d.都道府県コード又は市区町村コード).includes('123456')).toBe(true);
+    expect(formatedData.map((d) => d.名称_カナ).includes('テスト')).toBe(true);
+    expect(formatedData.map((d) => d.電話番号).includes('123-123')).toBe(true);
+    expect(formatedData.map((d) => d.緯度).includes('123.12')).toBe(true);
+    expect(formatedData.map((d) => d.開始時間).includes('12:00')).toBe(true);
+  });
+
+  test('ラベルのホワイトリストに入っているものが変換されているか', () => {
+    const data = [
+      {
+        '都道府県コ-ド又は市区町村コ-ド': '１２３４５６',
+        名前_カナ: 'ﾃｽﾄ',
+        電話: '１２３－１２３',
+        緯度経度: '１２３．１２',
+        開始時刻: '１２：００',
+      },
+    ];
+    const formatedData = formatter.format(data);
+    expect(formatedData.map((d) => d['都道府県コ-ド又は市区町村コ-ド']).includes('123456')).toBe(true);
+    expect(formatedData.map((d) => d.名前_カナ).includes('テスト')).toBe(true);
+    expect(formatedData.map((d) => d.電話).includes('123-123')).toBe(true);
+    expect(formatedData.map((d) => d.緯度経度).includes('123.12')).toBe(true);
+    expect(formatedData.map((d) => d.開始時刻).includes('12:00')).toBe(true);
+  });
+
+  test('ターゲットリストに入っているものは変換されないか', () => {
+    const data = [{ URL: 'https://１２３４５' }];
+    const formatedData = formatter.format(data);
+    expect(formatedData.map((d) => d.URL).includes('https://１２３４５')).toBe(true);
+  });
+});

--- a/datamanager/nodejs/items/formatter/2bytes2byte.ts
+++ b/datamanager/nodejs/items/formatter/2bytes2byte.ts
@@ -1,0 +1,32 @@
+import moji from 'moji';
+import { SchemeFormatterItemLabel } from '../../scheme/formatters/item_label';
+
+export class ItemFormatter2bytes2byte {
+  labelFormatter = new SchemeFormatterItemLabel();
+  formatTargetList = [
+    'NO',
+    '都道府県コード又は市区町村コード',
+    'POIコード',
+    '緯度',
+    '経度',
+    '電話番号',
+    '内線番号',
+    '法人番号',
+    '開始時間',
+    '終了時間',
+    '名称_カナ',
+  ];
+  format = (items: { [header: string]: string }[]) =>
+    items.map((item) => {
+      const formatedData: { [header: string]: string } = {};
+      for (const header of Object.keys(item)) {
+        const isTarget = this.formatTargetList.includes(this.labelFormatter.format(header).collectedLabel);
+        if (isTarget) {
+          formatedData[header] = moji(item[header]).convert('ZE', 'HE').convert('HK', 'ZK').toString();
+        } else {
+          formatedData[header] = item[header];
+        }
+      }
+      return formatedData;
+    });
+}

--- a/datamanager/nodejs/items/validator/address.test.ts
+++ b/datamanager/nodejs/items/validator/address.test.ts
@@ -4,13 +4,29 @@ describe('items/validator/address', () => {
   const addressValidator = new ItemValidatorAddress();
 
   test('文字列かどうか', async () => {
-    await expect(addressValidator.validateDataType(1000)).rejects.toEqual(new Error('住所は文字列である必要があります。'));
-    await expect(addressValidator.validateDataType(true)).rejects.toEqual(new Error('住所は文字列である必要があります。'));
+    await expect(addressValidator.validateDataType(1000)).rejects.toEqual(
+      new Error('住所は文字列である必要があります。'),
+    );
+    await expect(addressValidator.validateDataType(true)).rejects.toEqual(
+      new Error('住所は文字列である必要があります。'),
+    );
   });
 
   test('正しい住所がどうか', async () => {
-    await expect(addressValidator.validateDataType('北')).rejects.toEqual(new Error('住所が正しくありません。都道府県、市区町村と町丁目も入力してください（例：北→北海道札幌市西区24-2-2-3-3）。'));
-    await expect(addressValidator.validateDataType('北海道')).rejects.toEqual(new Error('住所が正しくありません。市区町村と町丁目も入力してください（例：北海道→北海道札幌市西区24-2-2-3-3）。'));
-    await expect(addressValidator.validateDataType('北海道札幌市西区')).rejects.toEqual(new Error('住所が正しくありません。町丁目も入力してください（例：北海道札幌市西区→北海道札幌市西区24-2-2-3-3）。'));
+    await expect(addressValidator.validateDataType('北')).rejects.toEqual(
+      new Error(
+        '住所が正しくありません。都道府県、市区町村と町丁目も入力してください（例：北→北海道札幌市西区24-2-2-3-3）。',
+      ),
+    );
+    await expect(addressValidator.validateDataType('北海道')).rejects.toEqual(
+      new Error(
+        '住所が正しくありません。市区町村と町丁目も入力してください（例：北海道→北海道札幌市西区24-2-2-3-3）。',
+      ),
+    );
+    await expect(addressValidator.validateDataType('北海道札幌市西区')).rejects.toEqual(
+      new Error(
+        '住所が正しくありません。町丁目も入力してください（例：北海道札幌市西区→北海道札幌市西区24-2-2-3-3）。',
+      ),
+    );
   });
 });

--- a/datamanager/nodejs/items/validator/address.ts
+++ b/datamanager/nodejs/items/validator/address.ts
@@ -9,14 +9,20 @@ export class ItemValidatorAddress {
     const result = await normalize(data);
 
     switch (result.level) {
-    case 0:
-      throw new Error('住所が正しくありません。都道府県、市区町村と町丁目も入力してください（例：北→北海道札幌市西区24-2-2-3-3）。');
-    case 1:
-      throw new Error('住所が正しくありません。市区町村と町丁目も入力してください（例：北海道→北海道札幌市西区24-2-2-3-3）。');
-    case 2:
-      throw new Error('住所が正しくありません。町丁目も入力してください（例：北海道札幌市西区→北海道札幌市西区24-2-2-3-3）。');
-    default:
-      break;
+      case 0:
+        throw new Error(
+          '住所が正しくありません。都道府県、市区町村と町丁目も入力してください（例：北→北海道札幌市西区24-2-2-3-3）。',
+        );
+      case 1:
+        throw new Error(
+          '住所が正しくありません。市区町村と町丁目も入力してください（例：北海道→北海道札幌市西区24-2-2-3-3）。',
+        );
+      case 2:
+        throw new Error(
+          '住所が正しくありません。町丁目も入力してください（例：北海道札幌市西区→北海道札幌市西区24-2-2-3-3）。',
+        );
+      default:
+        break;
     }
 
     return;

--- a/datamanager/nodejs/items/validator/address.ts
+++ b/datamanager/nodejs/items/validator/address.ts
@@ -9,20 +9,20 @@ export class ItemValidatorAddress {
     const result = await normalize(data);
 
     switch (result.level) {
-      case 0:
-        throw new Error(
-          '住所が正しくありません。都道府県、市区町村と町丁目も入力してください（例：北→北海道札幌市西区24-2-2-3-3）。',
-        );
-      case 1:
-        throw new Error(
-          '住所が正しくありません。市区町村と町丁目も入力してください（例：北海道→北海道札幌市西区24-2-2-3-3）。',
-        );
-      case 2:
-        throw new Error(
-          '住所が正しくありません。町丁目も入力してください（例：北海道札幌市西区→北海道札幌市西区24-2-2-3-3）。',
-        );
-      default:
-        break;
+    case 0:
+      throw new Error(
+        '住所が正しくありません。都道府県、市区町村と町丁目も入力してください（例：北→北海道札幌市西区24-2-2-3-3）。',
+      );
+    case 1:
+      throw new Error(
+        '住所が正しくありません。市区町村と町丁目も入力してください（例：北海道→北海道札幌市西区24-2-2-3-3）。',
+      );
+    case 2:
+      throw new Error(
+        '住所が正しくありません。町丁目も入力してください（例：北海道札幌市西区→北海道札幌市西区24-2-2-3-3）。',
+      );
+    default:
+      break;
     }
 
     return;

--- a/datamanager/nodejs/items/validator/barrierFreeInfo.test.ts
+++ b/datamanager/nodejs/items/validator/barrierFreeInfo.test.ts
@@ -4,7 +4,11 @@ describe('items/validator/barrierFreeInfo', () => {
   const barrierFreeInfoValidator = new ItemValidatorBarrierFreeInfo();
 
   test('文字列かどうか', () => {
-    expect(() => barrierFreeInfoValidator.validateDataType(1000)).toThrow('バリアフリー情報は文字列である必要があります。');
-    expect(() => barrierFreeInfoValidator.validateDataType(true)).toThrow('バリアフリー情報は文字列である必要があります。');
+    expect(() => barrierFreeInfoValidator.validateDataType(1000)).toThrow(
+      'バリアフリー情報は文字列である必要があります。',
+    );
+    expect(() => barrierFreeInfoValidator.validateDataType(true)).toThrow(
+      'バリアフリー情報は文字列である必要があります。',
+    );
   });
 });

--- a/datamanager/nodejs/package.json
+++ b/datamanager/nodejs/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/encoding-japanese": "^2.0.0",
     "@types/jest": "^28.1.4",
+    "@types/moji": "^0.5.0",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",
@@ -39,6 +40,7 @@
   },
   "dependencies": {
     "@geolonia/normalize-japanese-addresses": "^2.7.2",
-    "encoding-japanese": "^2.0.0"
+    "encoding-japanese": "^2.0.0",
+    "moji": "^0.5.1"
   }
 }

--- a/datamanager/nodejs/yarn.lock
+++ b/datamanager/nodejs/yarn.lock
@@ -738,6 +738,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/moji@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@types/moji/-/moji-0.5.0.tgz#4b68f789702baeb9aa5482ea68191ca4080c8b2b"
+  integrity sha512-oZhMgrG0iv5u1yICABzV4NrlpGOE7hNapc3atIMiQ1ebWOTkay/x1eMYbQPXjCxxk14Td3cqy7S+kvmGdE7NGA==
+
 "@types/node@*":
   version "18.0.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.3.tgz#463fc47f13ec0688a33aec75d078a0541a447199"
@@ -2767,6 +2772,13 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
+moji@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moji/-/moji-0.5.1.tgz#088eecd1c22c8f31a240adcf9c95e54f33eb54fb"
+  integrity sha512-xYylXOjBS9mE/d690InK3Y74NpE0El0TmAKDmKJveWk9jds/0Tl7MQP4yhavS0U64diEq+5ey2905nhCpIHE+Q==
+  dependencies:
+    object-assign "^3.0.0"
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -2830,6 +2842,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+  integrity sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==
 
 object-assign@^4.1.1:
   version "4.1.1"

--- a/webclient/src/components/Home/Description.tsx
+++ b/webclient/src/components/Home/Description.tsx
@@ -21,29 +21,16 @@ const StepCard = ({ children, title, subTitle }: StepCardProps) => {
       // 各要素の幅を均等にするために指定
       width="100%"
     >
-      <Stack
-        background="#42667A"
-        color="white"
-        px={6}
-        py={4}
-        borderTopRadius={8}
-      >
-        <Text fontSize="md">
-          {subTitle}
-        </Text>
-        <Heading size="md">
-          {title}
-        </Heading>
+      <Stack background="#42667A" color="white" px={6} py={4} borderTopRadius={8}>
+        <Text fontSize="md">{subTitle}</Text>
+        <Heading size="md">{title}</Heading>
       </Stack>
-      <Stack
-        px={6}
-        py={4}
-      >
+      <Stack px={6} py={4}>
         {children}
       </Stack>
     </Stack>
-  )
-}
+  );
+};
 
 export const Description = () => {
   return (
@@ -58,9 +45,7 @@ export const Description = () => {
         textStyle="navigationLarge"
         background="white"
       >
-        <Heading size="lg">
-          このツールについて
-        </Heading>
+        <Heading size="lg">このツールについて</Heading>
         <Text fontSize="md">
           オープンデータへの取組により、国民参加・官民協働の推進を通じた諸課題の解決、経済活性化、行政の高度化・効率化等が期待されています。
           しかし、自治体が公開しているオープンデータは増えてきているものの、機械判読性が高くフォーマットに沿った形で公開されているデータが少ないことが、活用する際の課題となっています。
@@ -70,45 +55,44 @@ export const Description = () => {
           このツールでは、政府が公開している「推奨データセット」で指定されているものを対象とし、4つのステップでデータ内容を確認し修正を行います。
           全てのステップが完了するとマップが表示され、データが活用できる状態となっているか確認ができるツールとなっています。
         </Text>
-        <Flex
-          alignItems="center"
-          px={6}
-          py={4}
-          bg={'information.bg.alert'}
-          borderRadius={8}
-        >
+        <Flex alignItems="center" px={6} py={4} bg={'information.bg.alert'} borderRadius={8}>
           <InfoOutlineIcon />
           <Text ml={6} fontSize="md">
             現在、試験段階（プロトタイプ）のため、「推奨データセット」の「公共施設一覧」にのみ対応しております。
           </Text>
         </Flex>
       </Stack>
-      <Flex
-        justifyContent="space-between"
-        my={6}
-        gap={6}
-      >
+      <Flex justifyContent="space-between" my={6} gap={6}>
         <StepCard
-          title={<>CSVファイルを<br />アップロードします</>}
+          title={
+            <>
+              CSVファイルを
+              <br />
+              アップロードします
+            </>
+          }
           subTitle="ステップ1"
         >
-          <Text fontSize="md">
-            ご自身のパソコンにある、CSVファイルをアップロードします。
-          </Text>
+          <Text fontSize="md">ご自身のパソコンにある、CSVファイルをアップロードします。</Text>
           <Text fontSize="md" pt={4}>
             <b>ご注意ください</b>
           </Text>
           <Text fontSize="md">
-            Excel（.xls/.xlsx）のファイルはアップロード対応していませんので、Excelファイルの場合はファイル形式を「CSV UTF-8(コンマ区切り)(.csv)」で保存した状態で、アップロードしてください。
+            Excel（.xls/.xlsx）のファイルはアップロード対応していませんので、Excelファイルの場合はファイル形式を「CSV
+            UTF-8(コンマ区切り)(.csv)」で保存した状態で、アップロードしてください。
           </Text>
         </StepCard>
         <StepCard
-          title={<>データを<br />自動変換します</>}
+          title={
+            <>
+              データを
+              <br />
+              自動変換します
+            </>
+          }
           subTitle="ステップ2"
         >
-          <Text fontSize="md">
-            アップロードされたCSVデータを、自動変換します。
-          </Text>
+          <Text fontSize="md">アップロードされたCSVデータを、自動変換します。</Text>
           <Box fontSize="md" pl={4}>
             <UnorderedList>
               <ListItem>文字コード</ListItem>
@@ -117,11 +101,17 @@ export const Description = () => {
             </UnorderedList>
           </Box>
           <Text fontSize="md">
-          上記のデータチェックが自動で行われます。各変換のローディングが完了するまでお待ちください。
+            上記のデータチェックが自動で行われます。各変換のローディングが完了するまでお待ちください。
           </Text>
         </StepCard>
         <StepCard
-          title={<>データ項目名を<br />整合させてください</>}
+          title={
+            <>
+              データ項目名を
+              <br />
+              整合させてください
+            </>
+          }
           subTitle="ステップ3"
         >
           <Text fontSize="md">
@@ -135,31 +125,28 @@ export const Description = () => {
           </Text>
         </StepCard>
         <StepCard
-          title={<>データ形式を<br />確認してください</>}
+          title={
+            <>
+              データ形式を
+              <br />
+              確認してください
+            </>
+          }
           subTitle="ステップ4"
         >
           <Text fontSize="md">
             データ形式確認を行います。項目名別に、細かく修正ポイントが表示されます。
           </Text>
-          <Text fontSize="md">
-            修正が進むと、完了ボタンが押せるようになります。
-          </Text>
+          <Text fontSize="md">修正が進むと、完了ボタンが押せるようになります。</Text>
           <Text fontSize="md">
             このステップまでに修正されたデータ（CSV）をダウンロードすることができるようになり、マップ表示が行えます。
           </Text>
         </StepCard>
       </Flex>
-      <Flex
-        justifyContent="center"
-        my={6}
-      >
+      <Flex justifyContent="center" my={6}>
         {/* NOTE: 見た目を塗りつぶしたボタンにするため、OstNavLinkではなくOstButtonを使用 */}
         <Link to="/upload-file">
-          <OstButton
-            size="L"
-            view="button"
-            iconRight={<Icon as={ArrowForwardIcon} w={6} h={6}/>}
-          >
+          <OstButton size="L" view="button" iconRight={<Icon as={ArrowForwardIcon} w={6} h={6} />}>
             ステップ1からはじめる
           </OstButton>
         </Link>
@@ -174,12 +161,8 @@ export const Description = () => {
         textStyle="navigationLarge"
         background="white"
       >
-        <Stack
-          alignItems="left"
-        >
-          <Heading size="md">
-            マップ表示のみ試したい方
-          </Heading>
+        <Stack alignItems="left">
+          <Heading size="md">マップ表示のみ試したい方</Heading>
           <Text fontSize="md">
             作成されたデータ（CSV）をアップロードすることでマップ表示が行えます。
           </Text>
@@ -194,4 +177,4 @@ export const Description = () => {
       </Flex>
     </>
   );
-}
+};

--- a/webclient/src/components/Home/SavedDatasetList.tsx
+++ b/webclient/src/components/Home/SavedDatasetList.tsx
@@ -3,7 +3,12 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/table';
 import { Avatar, Box, Flex, Heading, Text } from '@chakra-ui/react';
 import { FC, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { MdDeleteOutline, MdModeEditOutline, MdOutlineMap, MdOutlineTextSnippet } from "react-icons/md";
+import {
+  MdDeleteOutline,
+  MdModeEditOutline,
+  MdOutlineMap,
+  MdOutlineTextSnippet,
+} from 'react-icons/md';
 import { useRecoilValue } from 'recoil';
 import { useRemoveDatasetFromLocalstorage } from '../../hooks/useDataset';
 import { datasetListSelector } from '../../stores/dataset';
@@ -16,7 +21,9 @@ const RemoveAllButton: FC = () => {
   // (関数コンポーネント内のフックの個数が動的に変化するとReactがクラッシュするため https://ja.reactjs.org/docs/hooks-rules.html)
   const [deleting, setDeleting] = useState(false);
   // 先頭のdatasetを削除する関数
-  const { removeFromLocalstorage } = useRemoveDatasetFromLocalstorage({datasetUid: String(datasets[0]?.uid)});
+  const { removeFromLocalstorage } = useRemoveDatasetFromLocalstorage({
+    datasetUid: String(datasets[0]?.uid),
+  });
 
   useEffect(() => {
     // HACK: 以下のループにより、要素を逐次的にすべて削除
@@ -64,7 +71,7 @@ export const HomeSavedDatasetList: FC = () => {
         view="button"
         onClick={() => removeFromLocalstorage()}
         isLoading={executing}
-        iconRight={<Icon as={MdDeleteOutline} w={5} h={5}/>}
+        iconRight={<Icon as={MdDeleteOutline} w={5} h={5} />}
         mx={1}
       >
         削除
@@ -74,11 +81,13 @@ export const HomeSavedDatasetList: FC = () => {
 
   return (
     <>
-      <Heading size="lg" my={4}>データリスト</Heading>
+      <Heading size="lg" my={4}>
+        データリスト
+      </Heading>
       <Flex justifyContent="right">
-        <RemoveAllButton/>
+        <RemoveAllButton />
       </Flex>
-      <Table variant='striped' colorScheme='gray'>
+      <Table variant="striped" colorScheme="gray">
         <Thead>
           <Tr>
             <Th visibility="hidden">ファイル名</Th>
@@ -92,16 +101,34 @@ export const HomeSavedDatasetList: FC = () => {
             .map((dataset) => (
               <Tr key={dataset?.uid}>
                 <Td>
-                  <Flex align="center" >
-                    <Icon as={MdOutlineTextSnippet} w={6} h={6} mr={2}/><Text>{dataset?.datasetName}</Text>
+                  <Flex align="center">
+                    <Icon as={MdOutlineTextSnippet} w={6} h={6} mr={2} />
+                    <Text>{dataset?.datasetName}</Text>
                   </Flex>
                 </Td>
                 <Td>
                   <Flex align="center">
                     {/* NOTE: 文字を等幅にし全体の長さを揃えるためmonospaceを使用 */}
                     {/* TODO: 別箇所でも同様のデザインが必要になったらElement化 */}
-                    <Box px={3} py={1} fontFamily="monospace, serif" background="dimgray" color="white" borderLeftRadius={10}>ID</Box>
-                    <Box px={3} py={1} fontFamily="monospace, serif" background="lightgray" borderRightRadius={10}>{dataset?.uid}</Box>
+                    <Box
+                      px={3}
+                      py={1}
+                      fontFamily="monospace, serif"
+                      background="dimgray"
+                      color="white"
+                      borderLeftRadius={10}
+                    >
+                      ID
+                    </Box>
+                    <Box
+                      px={3}
+                      py={1}
+                      fontFamily="monospace, serif"
+                      background="lightgray"
+                      borderRightRadius={10}
+                    >
+                      {dataset?.uid}
+                    </Box>
                   </Flex>
                 </Td>
                 <Td>
@@ -109,7 +136,7 @@ export const HomeSavedDatasetList: FC = () => {
                     <OstButton
                       size="S"
                       view="button"
-                      iconRight={<Icon as={MdOutlineMap} w={5} h={5}/>}
+                      iconRight={<Icon as={MdOutlineMap} w={5} h={5} />}
                       mx={1}
                     >
                       マップ表示
@@ -119,7 +146,7 @@ export const HomeSavedDatasetList: FC = () => {
                     <OstButton
                       size="S"
                       view="button"
-                      iconRight={<Icon as={MdModeEditOutline} w={5} h={5}/>}
+                      iconRight={<Icon as={MdModeEditOutline} w={5} h={5} />}
                       mx={1}
                     >
                       編集

--- a/webclient/src/features/auto-convert/routes/AutoConvert.tsx
+++ b/webclient/src/features/auto-convert/routes/AutoConvert.tsx
@@ -12,13 +12,15 @@ import { StepLayout } from '../../../components/Layout';
 import { OstNavLink } from '../../../components/Elements/OstLink';
 import { useRecoilValue } from 'recoil';
 import { uploadedFileBufferAtom } from '../../../stores/upload_file';
-import { utilCharEncoding } from 'opendatatool-datamanager';
+import { utilCharEncoding, item2bytes2byteFormatter } from 'opendatatool-datamanager';
 import parser, { ParseResult } from 'papaparse';
 import { useImportDataset } from '../../../hooks/useDataset';
 
 export const AutoConvert: FC = () => {
   const [datasetUid, setDatasetUid] = useState<string>();
   const [charCodeConvertedData, setCharCodeConvertedData] = useState<string>();
+  const [charTypeConvertedData, setCharTypeConvertedData] =
+    useState<{ [header: string]: string }[]>();
   const [characterCodeProgress, setCharacterCodeProgress] = useState({
     status: 'waiting',
     errorMessage: '',
@@ -62,16 +64,29 @@ export const AutoConvert: FC = () => {
   }, [characterCodeProgress]);
 
   useEffect(() => {
-    if (characterTypeProgress.status === 'processing') {
-      setCharacterTypeProgress({ status: 'finished', errorMessage: '' });
-      setRequiredFieldProgress({ status: 'processing', errorMessage: '' });
+    if (characterTypeProgress.status === 'processing' && charCodeConvertedData) {
+      try {
+        const { data }: ParseResult<any> = parser.parse(charCodeConvertedData, {
+          header: true,
+        });
+        const convertedData = item2bytes2byteFormatter.format(data);
+        setCharTypeConvertedData(convertedData);
+        setCharacterTypeProgress({ status: 'finished', errorMessage: '' });
+        setRequiredFieldProgress({ status: 'processing', errorMessage: '' });
+      } catch (error) {
+        setCharacterTypeProgress({
+          status: 'failed',
+          errorMessage: '全角半角の変換に失敗しました',
+        });
+      }
     }
-  }, [characterTypeProgress]);
+  }, [characterTypeProgress, charCodeConvertedData]);
 
   useEffect(() => {
     if (
       requiredFieldProgress.status === 'processing' &&
       charCodeConvertedData &&
+      charTypeConvertedData &&
       uploadedFileBuffer
     ) {
       try {
@@ -84,7 +99,7 @@ export const AutoConvert: FC = () => {
         const importedDatasetUid = importRowData({
           datasetName: uploadedFileBuffer.fileName,
           headers: rowHeaders,
-          rowDatas: rowDataObject.data,
+          rowDatas: charTypeConvertedData,
         });
         setDatasetUid(importedDatasetUid);
         setRequiredFieldProgress({ status: 'finished', errorMessage: '' });
@@ -95,7 +110,7 @@ export const AutoConvert: FC = () => {
         });
       }
     }
-  }, [requiredFieldProgress, charCodeConvertedData]);
+  }, [requiredFieldProgress, charCodeConvertedData, charTypeConvertedData]);
 
   const statusStyle = (status: string) => {
     switch (status) {

--- a/webclient/src/features/data-editor/routes/DataEditor.tsx
+++ b/webclient/src/features/data-editor/routes/DataEditor.tsx
@@ -37,7 +37,11 @@ import civitanSearching from '../../../assets/civitan_searching.png';
 
 export const DataEditor: FC = () => {
   // Modalの状態管理
-  const { isOpen: isDownloadOpen, onOpen: onDownloadOpen, onClose: onDownloadClose } = useDisclosure();
+  const {
+    isOpen: isDownloadOpen,
+    onOpen: onDownloadOpen,
+    onClose: onDownloadClose,
+  } = useDisclosure();
   const { isOpen: isPreviewOpen, onOpen: onPreviewOpen, onClose: onPreviewClose } = useDisclosure();
 
   const { dataset_uid } = useParams<{ dataset_uid: string }>();
@@ -140,7 +144,7 @@ export const DataEditor: FC = () => {
             <OstButton
               size="L"
               view="button"
-              iconRight={<Icon as={DownloadIcon} w={6} h={6}/>}
+              iconRight={<Icon as={DownloadIcon} w={6} h={6} />}
               onClick={() => {
                 onDownloadClose();
                 exportCsv(datasetWithNewItems); // 完成したcsvのダウンロード
@@ -153,12 +157,7 @@ export const DataEditor: FC = () => {
         </ModalContent>
       </Modal>
 
-      <Modal
-        closeOnOverlayClick={false}
-        isOpen={isPreviewOpen}
-        onClose={onPreviewClose}
-        isCentered
-      >
+      <Modal closeOnOverlayClick={false} isOpen={isPreviewOpen} onClose={onPreviewClose} isCentered>
         <ModalOverlay />
         <ModalContent maxW="640px" maxH="640py">
           <ModalHeader bg="information.bg.disabled">
@@ -175,18 +174,13 @@ export const DataEditor: FC = () => {
           <ModalFooter justifyContent="center">
             {/* NOTE: 見た目を塗りつぶしたボタンにするため、OstNavLinkではなくOstButtonを使用 */}
             <Link to={`/${dataset_uid}/map`}>
-              <OstButton
-                size="L"
-                view="button"
-                iconRight={<Icon as={MdOutlineMap} w={6} h={6}/>}
-              >
+              <OstButton size="L" view="button" iconRight={<Icon as={MdOutlineMap} w={6} h={6} />}>
                 マップでプレビュー確認
               </OstButton>
             </Link>
           </ModalFooter>
         </ModalContent>
       </Modal>
-
     </StepLayout>
   );
 };

--- a/webclient/src/features/home/routes/Home.tsx
+++ b/webclient/src/features/home/routes/Home.tsx
@@ -7,13 +7,7 @@ export const Home = () => {
     <ContentLayout title="ホーム">
       <Box mx={6}>
         <Description />
-        <Box
-          background="white"
-          borderRadius={8}
-          my={6}
-          px={6}
-          py={6}
-        >
+        <Box background="white" borderRadius={8} my={6} px={6} py={6}>
           <HomeSavedDatasetList />
         </Box>
       </Box>

--- a/webclient/yarn.lock
+++ b/webclient/yarn.lock
@@ -2072,6 +2072,11 @@
     url-parse "^1.4.7"
     whatwg-fetch "^3.0.0"
 
+"@geolonia/japanese-numeral@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@geolonia/japanese-numeral/-/japanese-numeral-0.1.16.tgz#651b11f29e837545f0a9d8b7ffd8b832f67e2239"
+  integrity sha512-xzSsIHhyyjqNpW8qSh5bFMu3FJvyJGBbNZ/t8clPHkigjUdZ7Ck8wkzCkcwlVd00RkoHwGDLnvXx5W0WiGK0TQ==
+
 "@geolonia/mbgl-geolonia-control@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@geolonia/mbgl-geolonia-control/-/mbgl-geolonia-control-0.4.2.tgz#b2df9bc58c964142fbe7bfb9e55e17e6ab984460"
@@ -2081,6 +2086,15 @@
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/@geolonia/mbgl-gesture-handling/-/mbgl-gesture-handling-1.0.15.tgz#ac65eaf67b94fd82fb9611c76faf9f35155e522d"
   integrity sha512-etY8yCd2eAiZ/7kONFPLKAjFo1IQ1IICwhocCATD8I1peAeKmo3lEFGoRomeMkLKhiJOAeE/Uoy5gzyrQRj7lg==
+
+"@geolonia/normalize-japanese-addresses@^2.7.2":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@geolonia/normalize-japanese-addresses/-/normalize-japanese-addresses-2.7.2.tgz#cd531e8e2dc82b3bf874692adc1e642aa55be76e"
+  integrity sha512-590DaENe/iBbkz/85A/to11k9AfbHt2bdVRiNqNlBK62ZDqDIa7ESYTpVak/2EQXvV3bk77eEYMln3JGU7ZvkQ==
+  dependencies:
+    "@geolonia/japanese-numeral" "^0.1.16"
+    isomorphic-unfetch "^3.1.0"
+    lru-cache "^6.0.0"
 
 "@humanwhocodes/config-array@^0.10.4":
   version "0.10.4"
@@ -6648,6 +6662,14 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isomorphic-unfetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
+  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
+  dependencies:
+    node-fetch "^2.6.1"
+    unfetch "^4.2.0"
+
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3"
@@ -7684,6 +7706,13 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+moji@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moji/-/moji-0.5.1.tgz#088eecd1c22c8f31a240adcf9c95e54f33eb54fb"
+  integrity sha512-xYylXOjBS9mE/d690InK3Y74NpE0El0TmAKDmKJveWk9jds/0Tl7MQP4yhavS0U64diEq+5ey2905nhCpIHE+Q==
+  dependencies:
+    object-assign "^3.0.0"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -7745,6 +7774,13 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -7800,6 +7836,11 @@ nwsapi@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.1.tgz#10a9f268fbf4c461249ebcfe38e359aa36e2577c"
   integrity sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==
+
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+  integrity sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -7937,7 +7978,9 @@ open@^8.0.9, open@^8.4.0:
 opendatatool-datamanager@../datamanager/nodejs/:
   version "1.0.0"
   dependencies:
+    "@geolonia/normalize-japanese-addresses" "^2.7.2"
     encoding-japanese "^2.0.0"
+    moji "^0.5.1"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -10205,6 +10248,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 traverse@~0.6.6:
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.7.tgz#46961cd2d57dd8706c36664acde06a248f1173fe"
@@ -10305,6 +10353,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
@@ -10515,6 +10568,11 @@ web-vitals@^2.1.0:
   resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.4.tgz#76563175a475a5e835264d373704f9dde718290c"
   integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -10665,6 +10723,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
以下を対象項目として、全角半角の変換処理を導入。URLなど2bytes文字を含んでもよいものについては、対象から外しています。
```
'NO', '都道府県コード又は市区町村コード', 'POIコード', '緯度', '経度', '電話番号', '内線番号', '法人番号', '開始時間', '終了時間', '名称_カナ'
```

**今後検討すべきこと**
本来は、項目名正規化後に全角半角変換処理をするべきである。
なぜなら、変換処理の対象項目かどうかの判定に正規化されたラベルもしくは、項目正規化に使うホワイトリストに入っているラベルを用いているから。
例えば、ある自治体で「都道府県コード又は市区町村コード」を「コード」として、値を全角で入力している場合、全角半角の変換処理対象にはならない。その後項目の正規化で「都道府県コード又は市区町村コード」に正規化したとしても、全角半角の変換処理フェーズは終わっているので、値が全角のままであってしまう。

フェーズの入れ替えを行わないといけなくなり、影響範囲が大きいので一旦は、この課題を残した実装にしている。