### PR TITLE
エラーの数をカウント

### DIFF
--- a/webclient/src/components/Editor/DataEditorMain.tsx
+++ b/webclient/src/components/Editor/DataEditorMain.tsx
@@ -126,6 +126,7 @@ export const DataEditorMain: FC<Props> = ({ selectedItemUid }) => {
                   px={4}
                   py={2}
                   mb={1}
+                  className="ost-error"
                 >
                   {err.message}
                 </Text>
@@ -139,7 +140,7 @@ export const DataEditorMain: FC<Props> = ({ selectedItemUid }) => {
                 py={2}
                 mb={1}
               >
-                完了メッセージ
+                完了
               </Text>
             )}
             <OstInput

--- a/webclient/src/components/Editor/DataEditorNumOfError.tsx
+++ b/webclient/src/components/Editor/DataEditorNumOfError.tsx
@@ -1,0 +1,31 @@
+import { CheckIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import { Flex, Text } from '@chakra-ui/react';
+import { FC, useEffect, useState } from 'react';
+
+export const DataEditorNumOfError: FC = () => {
+  const [numOfErrorMessage, setNumOfError] = useState(0);
+
+  useEffect(() => {
+    setInterval(() => {
+      setNumOfError(document.getElementsByClassName('ost-error').length);
+    }, 1000);
+  }, []);
+
+  return (
+    <Flex
+      alignItems="center"
+      px={6}
+      py={4}
+      mb={10}
+      bg={numOfErrorMessage === 0 ? 'information.bg.active' : 'information.bg.alert'}
+      borderRadius={8}
+    >
+      {numOfErrorMessage === 0 ? <CheckIcon /> : <InfoOutlineIcon />}
+      <Text ml={6}>
+        {numOfErrorMessage === 0
+          ? '形式の確認が完了しました。'
+          : `${numOfErrorMessage}件のデータ形式を確認して修正してください。`}
+      </Text>
+    </Flex>
+  );
+};

--- a/webclient/src/components/Editor/DataEditorNumOfError.tsx
+++ b/webclient/src/components/Editor/DataEditorNumOfError.tsx
@@ -6,9 +6,11 @@ export const DataEditorNumOfError: FC = () => {
   const [numOfErrorMessage, setNumOfError] = useState(0);
 
   useEffect(() => {
-    setInterval(() => {
+    const count = setInterval(() => {
       setNumOfError(document.getElementsByClassName('ost-error').length);
     }, 1000);
+
+    return () => clearInterval(count);
   }, []);
 
   return (

--- a/webclient/src/components/Editor/index.ts
+++ b/webclient/src/components/Editor/index.ts
@@ -2,3 +2,4 @@ export * from './NormalizeDatasetItemLabel';
 export * from './DataEditorSidenav';
 export * from './DataEditorMain';
 export * from './MapEditorModal';
+export * from './DataEditorNumOfError';

--- a/webclient/src/features/data-editor/routes/DataEditor.tsx
+++ b/webclient/src/features/data-editor/routes/DataEditor.tsx
@@ -1,12 +1,6 @@
 import { FC, useState } from 'react';
 import { MdOutlineMap } from 'react-icons/md';
-import {
-  InfoOutlineIcon,
-  CheckIcon,
-  ArrowBackIcon,
-  ArrowForwardIcon,
-  DownloadIcon,
-} from '@chakra-ui/icons';
+import { ArrowBackIcon, ArrowForwardIcon, DownloadIcon } from '@chakra-ui/icons';
 import {
   Grid,
   GridItem,
@@ -26,7 +20,11 @@ import {
 import { StepLayout } from '../../../components/Layout';
 import { OstNavLink } from '../../../components/Elements/OstLink';
 import { OstButton } from '../../../components/Elements/OstButton';
-import { DataEditorMain, DataEditorSidenav } from '../../../components/Editor';
+import {
+  DataEditorMain,
+  DataEditorNumOfError,
+  DataEditorSidenav,
+} from '../../../components/Editor';
 import { Link, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { datasetAtom } from '../../../stores/dataset';
@@ -62,21 +60,7 @@ export const DataEditor: FC = () => {
       isProcessFinished={isCheckFinished}
     >
       {dataset?.datasetName}
-      <Flex
-        alignItems="center"
-        px={6}
-        py={4}
-        mb={10}
-        bg={isCheckFinished ? 'information.bg.active' : 'information.bg.alert'}
-        borderRadius={8}
-      >
-        {isCheckFinished ? <CheckIcon /> : <InfoOutlineIcon />}
-        <Text ml={6}>
-          {isCheckFinished
-            ? '形式の確認が完了しました。'
-            : `X件のデータ形式を確認して修正してください。`}
-        </Text>
-      </Flex>
+      <DataEditorNumOfError />
       <Grid gridTemplateColumns="200px 1fr" mt={4}>
         <GridItem borderRight="1px solid" borderColor="inputAreaBorder.active">
           <DataEditorSidenav


### PR DESCRIPTION
あまりかっこいいやり方では無いのですが、エラーメッセージのdomエレメントに`ost-error`のクラス名をつけて、1秒ごとにsetIntervalで監視する方法にしました。
データ件数が多くなるとuseEffectなどで監視しているとメモリリーク起こしてしまうようで、この実装が今のところ良さそうだなという判断です。ほかに良さげなやり方あれば教えていただけると