### PR TITLE
Fix/#146 file upload limit

### DIFF
--- a/webclient/package.json
+++ b/webclient/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "dexie": "^3.2.2",
     "framer-motion": "^7.3.6",
     "geojson": "^0.5.0",
     "opendatatool-datamanager": "../datamanager/nodejs/",

--- a/webclient/src/components/Editor/DataEditorSidenav.tsx
+++ b/webclient/src/components/Editor/DataEditorSidenav.tsx
@@ -22,10 +22,12 @@ export const DataEditorSidenav: FC<Props> = ({ onSelect, selectedItemUid }) => {
     if (selectedItemUid) {
       setSelectedItemUidState(selectedItemUid);
     } else {
-      setSelectedItemUidState(activeDatasetItemList[0].uid);
-      onSelect(activeDatasetItemList[0].uid);
+      if(activeDatasetItemList.length > 0) {
+        setSelectedItemUidState(activeDatasetItemList[0].uid);
+        onSelect(activeDatasetItemList[0].uid);
+      }
     }
-  }, [selectedItemUid]);
+  }, [selectedItemUid, activeDatasetItemList[0]]);
 
   const DatasetItem: FC<{ datasetUid: string; itemUid: string }> = ({ datasetUid, itemUid }) => {
     const item = useRecoilValue(datasetItemAtom({ datasetUid, itemUid }));
@@ -73,3 +75,7 @@ export const DataEditorSidenav: FC<Props> = ({ onSelect, selectedItemUid }) => {
     </Box>
   );
 };
+function useMemo(arg0: () => Dataset.Item[], arg1: Dataset.Item[][]) {
+  throw new Error('Function not implemented.');
+}
+

--- a/webclient/src/features/auto-convert/routes/AutoConvert.tsx
+++ b/webclient/src/features/auto-convert/routes/AutoConvert.tsx
@@ -16,7 +16,7 @@ import { utilCharEncoding } from 'opendatatool-datamanager';
 import parser, { ParseResult } from 'papaparse';
 import { useImportDataset } from '../../../hooks/useDataset';
 
-// indexDBの容量上限
+// indexDBの容量上限。単位MB
 const limitSize = 150;
 
 export const AutoConvert: FC = () => {

--- a/webclient/src/stores/dataset.ts
+++ b/webclient/src/stores/dataset.ts
@@ -1,4 +1,5 @@
 import { atom, atomFamily, selector, selectorFamily, DefaultValue } from 'recoil';
+import { db } from './db';
 import { AtomKeys, SelectorKeys } from './recoil_keys';
 
 // データセットの単体
@@ -7,16 +8,19 @@ export const datasetAtom = atomFamily<Dataset.Dataset | null, { uid: string }>({
   default: null,
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.datasets.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.dataset);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.datasets.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal) {
+            db.datasets.put({nodeKey: String(node.key), dataset: newVal})
+          }
         }
       });
     },
@@ -29,16 +33,19 @@ export const datasetUidListAtom = atom<string[]>({
   default: [],
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.datasetUids.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.uids);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.datasetUids.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal.length > 0) {
+            db.datasetUids.put({nodeKey: String(node.key), uids: newVal})
+          }
         }
       });
     },
@@ -67,16 +74,19 @@ export const datasetItemAtom = atomFamily<
   default: null,
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.items.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.item);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.items.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal) {
+            db.items.put({nodeKey: String(node.key), item: newVal})
+          }
         }
       });
     },
@@ -89,16 +99,19 @@ export const datasetItemUidListAtom = atomFamily<string[], { datasetUid: string 
   default: [],
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.datasetItemUids.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.uids);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.datasetItemUids.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal.length > 0) {
+            db.datasetItemUids.put({nodeKey: String(node.key), uids: newVal})
+          }
         }
       });
     },
@@ -143,16 +156,19 @@ export const datasetSingleRowAtom = atomFamily<
   default: null,
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.rows.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.singleRow);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.rows.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal) {
+            db.rows.put({nodeKey: String(node.key), singleRow: newVal})
+          }
         }
       });
     },
@@ -165,16 +181,19 @@ export const datasetSingleRowUidListAtom = atomFamily<string[], { datasetUid: st
   default: [],
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.datasetSingleRowUids.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.uids);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.datasetSingleRowUids.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal.length > 0) {
+            db.datasetSingleRowUids.put({nodeKey: String(node.key), uids: newVal})
+          }
         }
       });
     },
@@ -222,16 +241,19 @@ export const datasetSingleCellAtom = atomFamily<
   default: null,
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.cells.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.singleCell);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.cells.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal) {
+            db.cells.put({nodeKey: String(node.key), singleCell: newVal})
+          }
         }
       });
     },
@@ -247,16 +269,19 @@ export const datasetSingleCellUidListByItemAtom = atomFamily<
   default: [],
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
+      db.datasetSingleCellUidsByItems.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.uids);
+        }
+      })
 
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.datasetSingleCellUidsByItems.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal.length > 0) {
+            db.datasetSingleCellUidsByItems.put({nodeKey: String(node.key), uids: newVal})
+          }
         }
       });
     },
@@ -272,16 +297,18 @@ export const datasetSingleCellUidListByRowAtom = atomFamily<
   default: [],
   effects: [
     ({ setSelf, onSet, node }) => {
-      const savedValue = localStorage.getItem(node.key);
-      if (savedValue !== null) {
-        setSelf(JSON.parse(savedValue));
-      }
-
+      db.datasetSingleCellUidListByRows.get(String(node.key)).then(v => {
+        if (v) {
+          setSelf(v.uids);
+        }
+      })
       onSet((newVal, _, isReset) => {
         if (newVal instanceof DefaultValue || isReset) {
-          localStorage.removeItem(node.key);
+          db.datasetSingleCellUidListByRows.delete(String(node.key))
         } else {
-          localStorage.setItem(node.key, JSON.stringify(newVal));
+          if(newVal.length > 0) {
+            db.datasetSingleCellUidListByRows.put({nodeKey: String(node.key), uids: newVal})
+          }
         }
       });
     },

--- a/webclient/src/stores/db.ts
+++ b/webclient/src/stores/db.ts
@@ -1,0 +1,54 @@
+import Dexie, { Table } from 'dexie';
+
+interface DatasetType {
+    nodeKey: string;
+    dataset: Dataset.Dataset;
+}
+interface ItemType {
+    nodeKey: string;
+    item: Dataset.Item;
+}
+interface SingleRowType {
+    nodeKey: string;
+    singleRow: Dataset.SingleRow;
+}
+interface SingleCellType {
+    nodeKey: string;
+    singleCell: Dataset.SingleCell;
+}
+interface idListType {
+    nodeKey: string;
+    uids: string[];
+}
+
+export class openDataFormatterDB extends Dexie {
+
+    datasets!: Table<DatasetType>;
+    items!: Table<ItemType>;
+    rows!: Table<SingleRowType>;
+    cells!: Table<SingleCellType>;
+    datasetUids!: Table<idListType>;
+    datasetItemUids!: Table<idListType>;
+    datasetSingleRowUids!: Table<idListType>;
+    datasetSingleCellUidsByItems!: Table<idListType>;
+    datasetSingleCellUidListByRows!: Table<idListType>;
+    datasetSingleCellUids!: Table<idListType>;
+  
+    constructor() {
+      super('openDataFormatterDB');
+      this.version(1).stores({
+        datasets: '&nodeKey, dataset',
+        items: '&nodeKey, item',
+        rows: '&nodeKey, singleRow',
+        cells: '&nodeKey, singleCell',
+        datasetUids: '&nodeKey, uids',
+        datasetItemUids: '&nodeKey, uids',
+        datasetSingleRowUids: '&nodeKey, uids',
+        datasetSingleCellUidsByItems: '&nodeKey, uids',
+        datasetSingleCellUidListByRows: '&nodeKey, uids',
+        datasetSingleCellUids: '&nodeKey, uids'
+      });
+    }
+  }
+  
+  export const db = new openDataFormatterDB();

--- a/webclient/src/stores/db.ts
+++ b/webclient/src/stores/db.ts
@@ -35,7 +35,7 @@ export class openDataFormatterDB extends Dexie {
     datasetSingleCellUids!: Table<idListType>;
   
     constructor() {
-      super('openDataFormatterDB');
+      super('formatterDB');
       this.version(1).stores({
         datasets: '&nodeKey, dataset',
         items: '&nodeKey, item',

--- a/webclient/yarn.lock
+++ b/webclient/yarn.lock
@@ -4821,6 +4821,11 @@ detective@^5.2.1:
     defined "^1.0.0"
     minimist "^1.2.6"
 
+dexie@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.2.tgz#fa6f2a3c0d6ed0766f8d97a03720056f88fe0e01"
+  integrity sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==
+
 didyoumean@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"


### PR DESCRIPTION
close #146 

[対応したこと]
- localstorageからindexedDBへ保存先を変更
- 現在の保存容量を確認して規定値を超えてたらエラーをユーザーに表示させる

[実装結果]
・完了時
<img width="1400" alt="Screen Shot 2022-11-14 at 1 03 44" src="https://user-images.githubusercontent.com/26044110/201531750-65ee2c0a-65a2-4b75-88f8-5b01cc6ea9ec.png">

・エラー時
<img width="1379" alt="Screen Shot 2022-11-14 at 1 03 22" src="https://user-images.githubusercontent.com/26044110/201531753-93db3a30-7d12-4fef-8bc1-505f1b416794.png">

[相談事項&対応したい事]
- indexDBに変えた事によってread/writeに時間かかってます。特にreadはloadingコンポーネントを別issueで入れ込んだ方がいいかも。
- 保存容量の上限値(150)を適当に決めてるのですが、どれくらいがいいですかね
- そもそも変換ステップ時に入れ込んでるが、その前とかが良い？
- プロセスの文言もこれでいいのか

