### PR TITLE
URLが空白の場合を許可する

### DIFF
--- a/datamanager/nodejs/items/validator/url.test.ts
+++ b/datamanager/nodejs/items/validator/url.test.ts
@@ -12,4 +12,8 @@ describe('items/validator/url', () => {
     expect(() => urlValidator.validateDataType('https//google.com')).toThrow('入力がURLとして認識されません。');
     expect(() => urlValidator.validateDataType('google．com')).toThrow('入力がURLとして認識されません。');
   });
+
+  test('空白の場合は値が存在しないものとして許容', () => {
+    expect(() => urlValidator.validateDataType('')).not.toThrow('入力がURLとして認識されません。');
+  });
 });

--- a/datamanager/nodejs/items/validator/url.ts
+++ b/datamanager/nodejs/items/validator/url.ts
@@ -4,6 +4,11 @@ export class ItemValidatorUrl {
       throw new Error('URLは文字列である必要があります。');
     }
 
+    // 空白の場合は値が存在しないものとして許容（バリデーションチェックしない）
+    if (data === '') {
+      return;
+    }
+
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const unused = new URL(data);


### PR DESCRIPTION
URLは必須項目ではないため、未入力で空白の場合にSTEP4でバリデーションエラーが発生しないようにしました。

![image](https://user-images.githubusercontent.com/36665200/206836183-771af493-5065-4465-9a1f-769002790a3e.png)

close #191 