### PR TITLE
STEP4でバリデーションエラーを全て解消するまで完了ボタンが押せないように修正

### DIFF
--- a/webclient/src/components/Editor/DataEditorSidenav.tsx
+++ b/webclient/src/components/Editor/DataEditorSidenav.tsx
@@ -85,6 +85,7 @@ const DatasetItem: FC<{
             borderRadius="full"
             as="span"
             display="inline-block"
+            className="ost-error"
           >
             {errorLength}件
           </Box>

--- a/webclient/src/components/Elements/OstLink/OstNavLink.tsx
+++ b/webclient/src/components/Elements/OstLink/OstNavLink.tsx
@@ -9,10 +9,11 @@ export type OstNavLinkProps = {
   children?: React.ReactNode;
   url?: string;
   to?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
 };
 
 export const OstNavLink = forwardRef<LinkProps & OstNavLinkProps, 'button'>((props, ref) => {
-  const { isDisabled, iconLeft, iconRight, ...linkProps } = props;
+  const { isDisabled, iconLeft, iconRight, onClick, ...linkProps } = props;
 
   return (
     <Link
@@ -20,6 +21,9 @@ export const OstNavLink = forwardRef<LinkProps & OstNavLinkProps, 'button'>((pro
       href={linkProps.url}
       as={linkProps.to && !isDisabled ? RouterLink : 'span'}
       to={linkProps.to}
+      // onClick は as で別コンポーネントを指定している場合 isDisabled と連動しないため、自前で判定
+      // https://github.com/chakra-ui/chakra-ui/issues/1436
+      onClick={onClick && !isDisabled ? onClick : () => undefined}
       display="flex"
       alignItems="center"
       gap={2}


### PR DESCRIPTION
全項目のバリデーションエラーが0件になるまで完了ボタンを押せないようにしました。

修正点

- 無効化状態のボタンをクリックしてもモーダルが開かないように変更
- 現在開いている項目以外にエラーがある場合もボタンを無効化