### PR TITLE
緯度、経度が空欄or整数値の場合にSTEP4の画面がクラッシュしないようにする

### DIFF
--- a/webclient/src/components/Editor/MapEditorModal.tsx
+++ b/webclient/src/components/Editor/MapEditorModal.tsx
@@ -37,8 +37,10 @@ type Props = {
 
 const orgRoundAtSix = (value: number): string => {
   // NOTE: 小数点６桁で丸める
-  const roundedValue = String(Math.round(value * 1000000) / 1000000);
-  return `${roundedValue}${new Array(6 - roundedValue.split('.')[1]?.length).fill('0').join('')}`;
+  if (Number.isNaN(value)) {
+    return (0).toFixed(6);
+  }
+  return value.toFixed(6);
 };
 
 const convertLngLat = (LngLat: LngLat): LngLatString => {


### PR DESCRIPTION
「緯度」「軽度」項目に「整数値」、「空欄」、「数字以外の要素」等が指定された場合にSTEP4の画面がクラッシュしないように修正しました。